### PR TITLE
S3 implementation patch

### DIFF
--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -6,75 +6,113 @@ from library import (
     aws_secret_access_key,
     aws_s3_endpoint,
     aws_s3_bucket,
-    pp
+    pp,
 )
 
 s3 = S3(aws_access_key_id, aws_secret_access_key, aws_s3_endpoint, aws_s3_bucket)
-version = date.today().strftime("%Y-%m-%d")
+version = "2021-01-22"
+
 
 def test_s3_upload_file():
     # Make sure file doesn't already exist
-    assert s3.exists(f'test/{version}/test.yml') == False
+    if s3.exists(f"test/{version}/test.yml"):
+        s3.rm(f"test/{version}/test.yml")
 
-    '''
-    if s3.exists(f'test/{version}/test.yml') == True:
-        s3.rm(f'test/{version}/test.yml')
-    '''
+    assert not s3.exists(f"test/{version}/test.yml")
 
     # Attempt to upload to {version}/test.yml
-    s3.upload_file(name='test', version=version, path=f"{Path(__file__).parent}/data/socrata.yml")
+    s3.put(key=f"test/{version}/test.yml", path=f"{Path(__file__).parent}/data/socrata.yml")
 
     # Make sure file now exists
-    assert s3.exists(f'test/{version}/test.yml') == True
+    assert s3.exists(f"test/{version}/test.yml")
+    s3.rm(f"test/{version}/test.yml")
+
 
 def test_s3_ls():
-    pp.pprint(s3.ls('test'))
+    pp.pprint(s3.ls("test"))
     assert True
+
 
 def test_s3_info():
     print("\nTest info...")
+    if not s3.exists(f"test/{version}/test.yml"):
+        s3.upload_file(
+            name="test",
+            version=version,
+            path=f"{Path(__file__).parent}/data/socrata.yml",
+        )
+
     # Make sure file exists before trying to pull info
-    assert s3.exists(f'test/{version}/test.yml') == True
+    assert s3.exists(f"test/{version}/test.yml")
 
     # Pull file info
-    info = s3.info(key=f'test/{version}/test.yml')
+    info = s3.info(key=f"test/{version}/test.yml")
     if info:
         pp.pprint(info)
     else:
-        pp.pprint('File exists, but no info retrieved.')
+        pp.pprint("File exists, but no info retrieved.")
+    s3.rm(f"test/{version}/test.yml")
+
 
 def test_s3_cp():
     print("\nTest cp...")
+    if not s3.exists(f"test/{version}/test.yml"):
+        s3.upload_file(
+            name="test",
+            version=version,
+            path=f"{Path(__file__).parent}/data/socrata.yml",
+        )
     # Make sure the {version} version exists, but the latest version doesn't
-    assert s3.exists(f'test/{version}/test.yml') == True
+    assert s3.exists(f"test/{version}/test.yml")
 
     # Copy {version} to latest
-    s3.cp(source_key=f'test/{version}/test.yml', dest_key='test/latest/test.yml')
+    s3.cp(source_key=f"test/{version}/test.yml", dest_key="test/latest/test.yml")
 
     # Make sure the {version} version exists, and the latest version doesn't
-    assert s3.exists(f'test/{version}/test.yml') == True
-    assert s3.exists('test/latest/test.yml') == True
+    assert s3.exists(f"test/{version}/test.yml")
+    assert s3.exists("test/latest/test.yml")
+    s3.rm(f"test/{version}/test.yml", f"test/latest/test.yml")
+
 
 def test_s3_mv():
     print("\nTest mv...")
+    if not s3.exists(f"test/{version}/test.yml"):
+        s3.upload_file(
+            name="test",
+            version=version,
+            path=f"{Path(__file__).parent}/data/socrata.yml",
+        )
+    if s3.exists("test/moved/test.yml"):
+        s3.rm("test/moved/test.yml")
     # Make sure that the {version} version exists, but the moved version doesn't
-    assert s3.exists(f'test/{version}/test.yml') == True
-    assert s3.exists('test/moved/test.yml') == False
+    assert s3.exists(f"test/{version}/test.yml")
+    assert not s3.exists("test/moved/test.yml")
 
     # Move the {version} version to moved
-    s3.mv(source_key=f'test/{version}/test.yml', dest_key='test/moved/test.yml')
+    s3.mv(source_key=f"test/{version}/test.yml", dest_key="test/moved/test.yml")
 
     # Make sure that the moved version exists, but the {version} version doesn't
-    assert s3.exists('test/moved/test.yml') == True
-    assert s3.exists(f'test/{version}/test.yml') == False
+    assert s3.exists("test/moved/test.yml")
+    assert not s3.exists(f"test/{version}/test.yml")
+    s3.rm("test/moved/test.yml")
+
 
 def test_s3_rm():
     print("\nTest rm and clean up test directory...")
     # Make sure that the moved version and latest version exist prior to rm
-    assert s3.exists('test/moved/test.yml') == True
-    assert s3.exists('test/latest/test.yml') == True
+    if not s3.exists("test/moved/test.yml"):
+        s3.put(
+            key="test/moved/test.yml", path=f"{Path(__file__).parent}/data/socrata.yml"
+        )
+    if not s3.exists("test/latest/test.yml"):
+        s3.put(
+            key="test/latest/test.yml", path=f"{Path(__file__).parent}/data/socrata.yml"
+        )
+
+    assert s3.exists("test/moved/test.yml")
+    assert s3.exists("test/latest/test.yml")
     # Remove files
-    s3.rm(['test/moved/test.yml','test/latest/test.yml'])
+    s3.rm(*["test/moved/test.yml", "test/latest/test.yml"])
     # Make sure the file no longer exists
-    assert s3.exists('test/moved/test.yml') == False
-    assert s3.exists('test/latest/test.yml') == False
+    assert not s3.exists("test/moved/test.yml")
+    assert not s3.exists("test/latest/test.yml")


### PR DESCRIPTION
- adding put/rm to make sure each test cases are independent of each other
- allow different forms of input for rm so it's more flexible to use e.g.
```python
s3.rm('file')
s3.rm('file1', 'file2')
s3.rm(*['file1', 'file2'])
```

to test all:
`poetry run pytest tests/test_s3.py -s`
to test a specific function:
`poetry run pytest tests/test_s3.py::test_s3_ls -s`
> note the `-s` flag is optional, it allows print output (via stdout) to be included in the test output, otherwise they get ignored

## Noticed issue: 
it seems like digitalocean has rate limits on API calls, sometimes `cp` and `mv` would fail, sometimes not. this is a [known issue](https://www.digitalocean.com/community/questions/rate-limiting-on-spaces). but the code works fine with minio, if we swap out the credentials