### PR TITLE
Add show command

### DIFF
--- a/library/archive.py
+++ b/library/archive.py
@@ -94,7 +94,7 @@ class Archive:
         for _file in output_files:
             if push:
                 key = _file.replace(base_path + "/", "")
-                self.s3.put(_file, key, acl, metadata={"Version": version})
+                self.s3.put(_file, key, acl, metadata={"version": version})
             if push and latest:
                 # Upload file to a latest directory, where version metadata is version
                 # This allows us to get the version associated with each file in latest
@@ -102,7 +102,7 @@ class Archive:
                     _file,
                     key.replace(version, "latest"),
                     acl,
-                    metadata={"Version": version},
+                    metadata={"version": version},
                 )
             if clean:
                 os.remove(_file)

--- a/library/archive.py
+++ b/library/archive.py
@@ -94,10 +94,15 @@ class Archive:
         for _file in output_files:
             if push:
                 key = _file.replace(base_path + "/", "")
-                self.s3.put(_file, key, acl, version=version)
+                self.s3.put(_file, key, acl, metadata={"Version": version})
             if push and latest:
                 # Upload file to a latest directory, where version metadata is version
                 # This allows us to get the version associated with each file in latest
-                self.s3.put(_file, key.replace(version, "latest"), acl, version=version)
+                self.s3.put(
+                    _file,
+                    key.replace(version, "latest"),
+                    acl,
+                    metadata={"Version": version},
+                )
             if clean:
                 os.remove(_file)

--- a/library/archive.py
+++ b/library/archive.py
@@ -94,8 +94,10 @@ class Archive:
         for _file in output_files:
             if push:
                 key = _file.replace(base_path + "/", "")
-                self.s3.put(_file, key, acl)
+                self.s3.put(_file, key, acl, version=version)
             if push and latest:
-                self.s3.put(_file, key.replace(version, "latest"), acl)
+                # Upload file to a latest directory, where version metadata is version
+                # This allows us to get the version associated with each file in latest
+                self.s3.put(_file, key.replace(version, "latest"), acl, version=version)
             if clean:
                 os.remove(_file)

--- a/library/cli.py
+++ b/library/cli.py
@@ -69,9 +69,9 @@ def show(
         message = "\n".join([f"File: {f} \t Last upload date: {d}" for f, d in upload_dates.items()])
         typer.echo(message)
     if version:
-        keys = s3.ls(f"datasets/{name}/", detail=True)
-        upload_dates = {k['Key'].replace(f"datasets/{name}/", ""):str(k['Version']) for k in keys}
-        message = "\n".join([f"File: {f} \t Version: {v}" for f, v in upload_dates.items()])
+        keys = s3.ls(f"datasets/{name}/")
+        versions = {k.replace(f"datasets/{name}/", ""):s3.info(k)["Metadata"]["version"] for k in keys}
+        message = "\n".join([f"File: {f} \t Version: {v}" for f, v in versions.items()])
         typer.echo(message)
 
 def run() -> None:

--- a/library/cli.py
+++ b/library/cli.py
@@ -50,7 +50,8 @@ def archive(
 @app.command()
 def show(
     name: str,
-    uploaded: bool = typer.Option(False, "--uploaded", "-u", help="Show upload dates for each file")
+    uploaded: bool = typer.Option(False, "--uploaded", "-u", help="Show upload dates for each file"),
+    version: bool = typer.Option(False, "--version", "-v", help="Show version for each file")
 ) -> None:
 # fmt: on
     """
@@ -58,14 +59,19 @@ def show(
     date for each file.
     """
     s3 = S3(aws_access_key_id, aws_secret_access_key, aws_s3_endpoint, aws_s3_bucket)
-    if not uploaded:
+    if not uploaded and not version:
         keys = s3.ls(f"datasets/{name}/")
         message = "\n".join([k.replace(f"datasets/{name}/", "") for k in keys])
         typer.echo(message)
     if uploaded:
         keys = s3.ls(f"datasets/{name}/", detail=True)
         upload_dates = {k['Key'].replace(f"datasets/{name}/", ""):str(k['LastModified']) for k in keys}
-        message = "\n".join([f"File: {v} \t Last upload date: {d}" for v, d in upload_dates.items()])
+        message = "\n".join([f"File: {f} \t Last upload date: {d}" for f, d in upload_dates.items()])
+        typer.echo(message)
+    if version:
+        keys = s3.ls(f"datasets/{name}/", detail=True)
+        upload_dates = {k['Key'].replace(f"datasets/{name}/", ""):str(k['Version']) for k in keys}
+        message = "\n".join([f"File: {f} \t Version: {v}" for f, v in upload_dates.items()])
         typer.echo(message)
 
 def run() -> None:

--- a/library/s3.py
+++ b/library/s3.py
@@ -33,10 +33,15 @@ class S3:
         response = self.put(path, key, acl)
         return response
 
-    def put(self, path: str, key: str, acl: str = "public-read") -> dict:
+    def put(
+        self, path: str, key: str, acl: str = "public-read", version: str = ""
+    ) -> dict:
         try:
             response = self.client.upload_file(
-                path, self.bucket, key, ExtraArgs={"ACL": acl}
+                path,
+                self.bucket,
+                key,
+                ExtraArgs={"ACL": acl, "Metadata": {"Version": version}},
             )
         except ClientError as e:
             logging.error(e)
@@ -75,6 +80,7 @@ class S3:
         source_key: str,
         dest_key: str,
         acl: str = "public-read",
+        version: str = "",
         info: bool = False,
     ) -> dict:
         """
@@ -85,6 +91,7 @@ class S3:
         key: path within the bucket of the file to copy
         dest_ket: new path for the copy
         acl: acl for newly created file
+        version: version to save as s3 metadata
         """
         try:
             response = self.client.copy_object(
@@ -92,6 +99,7 @@ class S3:
                 Key=dest_key,
                 CopySource={"Bucket": self.bucket, "Key": source_key},
                 ACL=acl,
+                Metadata={"Version": version},
             )
             if info:
                 return self.info(key=dest_key)
@@ -118,6 +126,7 @@ class S3:
         source_key: str,
         dest_key: str,
         acl: str = "public-read",
+        version: str = "",
         info: bool = False,
     ):
         """
@@ -129,10 +138,13 @@ class S3:
         source_key: path within the bucket of the file to move
         dest_ket: new path for the copy
         acl: acl for newly created file
+        version: version to save as s3 metadata
         info: if true, get info for file in its new location
         """
 
-        response = self.cp(source_key=source_key, dest_key=dest_key, acl=acl)
+        response = self.cp(
+            source_key=source_key, dest_key=dest_key, acl=acl, version=version
+        )
         response = self.rm(source_key)
         if info:
             return self.info(key=dest_key)

--- a/library/s3.py
+++ b/library/s3.py
@@ -34,14 +34,11 @@ class S3:
         return response
 
     def put(
-        self, path: str, key: str, acl: str = "public-read", version: str = ""
+        self, path: str, key: str, acl: str = "public-read", metadata: dict = {}
     ) -> dict:
         try:
             response = self.client.upload_file(
-                path,
-                self.bucket,
-                key,
-                ExtraArgs={"ACL": acl, "Metadata": {"Version": version}},
+                path, self.bucket, key, ExtraArgs={"ACL": acl, "Metadata": metadata}
             )
         except ClientError as e:
             logging.error(e)
@@ -80,7 +77,7 @@ class S3:
         source_key: str,
         dest_key: str,
         acl: str = "public-read",
-        version: str = "",
+        metadata: dict = {},
         info: bool = False,
     ) -> dict:
         """
@@ -99,7 +96,7 @@ class S3:
                 Key=dest_key,
                 CopySource={"Bucket": self.bucket, "Key": source_key},
                 ACL=acl,
-                Metadata={"Version": version},
+                Metadata=metadata,
             )
             if info:
                 return self.info(key=dest_key)
@@ -126,7 +123,7 @@ class S3:
         source_key: str,
         dest_key: str,
         acl: str = "public-read",
-        version: str = "",
+        metadata: dict = {},
         info: bool = False,
     ):
         """
@@ -143,7 +140,7 @@ class S3:
         """
 
         response = self.cp(
-            source_key=source_key, dest_key=dest_key, acl=acl, version=version
+            source_key=source_key, dest_key=dest_key, acl=acl, metadata=metadata
         )
         response = self.rm(source_key)
         if info:

--- a/library/s3.py
+++ b/library/s3.py
@@ -88,7 +88,7 @@ class S3:
         key: path within the bucket of the file to copy
         dest_ket: new path for the copy
         acl: acl for newly created file
-        version: version to save as s3 metadata
+        metadata: dictionary to save as custom s3 metadata
         """
         try:
             response = self.client.copy_object(
@@ -135,7 +135,7 @@ class S3:
         source_key: path within the bucket of the file to move
         dest_ket: new path for the copy
         acl: acl for newly created file
-        version: version to save as s3 metadata
+        metadata: dictionary to save as custom s3 metadata
         info: if true, get info for file in its new location
         """
 

--- a/library/templates/nypl_libraries.yml
+++ b/library/templates/nypl_libraries.yml
@@ -1,0 +1,34 @@
+dataset:
+  name: &name nypl_libraries
+  version: "20210122"
+  acl: public-read
+  source:
+    url:
+      path: https://raw.githubusercontent.com/NYCPlanning/recipes/master/recipes/facdb/nypl_libraries.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+      - "X_POSSIBLE_NAMES=lon"
+      - "Y_POSSIBLE_NAMES=lat"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "OVERWRITE=YES"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      NYPL libraries is a dataset that we webscrape and store
+      in a csv format, checkout the nypl website(https://www.nypl.org/locations)
+      for more information
+    url: "https://www.nypl.org/locations"
+    dependents: []

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -32,7 +32,7 @@ def test_s3_upload_file():
 
 
 def test_s3_ls():
-    pp.pprint(s3.ls("test"))
+    pp.pprint(s3.ls("test", detail=True))
     assert True
 
 


### PR DESCRIPTION
#26 
+ Modifies`put`, `cp`, and `mv` functions in s3 to pass a dict as custom s3 metadata
+ Modifies archive `__call__` function to keep version s3 metadata when writing a file to latest -- we can replace/expand this with other metadata as desired
+ Adds `show` as a CLI command with options
    + Show all files available in library for a given dataset name
    + Show all files available in library for a given dataset name, along with last upload date
    + Show all files available in library for a given dataset name, along with version. For all files except for those in latest, version and directory should be the same.
