### PR TITLE
Add step to remove old versions from latest

### DIFF
--- a/library/archive.py
+++ b/library/archive.py
@@ -104,5 +104,19 @@ class Archive:
                     acl,
                     metadata={"version": version},
                 )
+
+                # Find all files in latest where the version (stored in s3 metadata)
+                # does not match the version of the file currently getting added to latest
+                keys_in_latest = self.s3.ls(key.rsplit("/", 1)[0])
+                diff_version = [
+                    k
+                    for k in keys_in_latest
+                    if self.s3.info(k)["Metadata"]["version"] != version
+                ]
+
+                # Remove keys from the latest directory that have versions different
+                # from the version of the file currently getting added to latest
+                s3.rm(*diff_version)
+
             if clean:
                 os.remove(_file)


### PR DESCRIPTION
#29 

After uploading file to latest, finds other files in latest where the version is not the same as the one uploaded then removes them.