### PR TITLE
File is a cached property. Checks do not require file as parameter

### DIFF
--- a/library/validator.py
+++ b/library/validator.py
@@ -78,13 +78,13 @@ class Validator:
         return True
 
     # Check that source name matches filename and destination
-    def dataset_name_matches(self, name, file) -> bool:
-        dataset = file['dataset']
+    def dataset_name_matches(self, name) -> bool:
+        dataset = self.__file['dataset']
         return (dataset['name'] == name) and (dataset['name'] == dataset['destination']['name'])
 
     # Check that source has only one source from either url, socrata or script
-    def has_only_one_source(self, file):
-        dataset = file['dataset']
+    def has_only_one_source(self):
+        dataset = self.__file['dataset']
         source_fields = list(dataset['source'].keys())
         # In other words: if url is in source, socrata or script cannot be.
         # If url is NOT in source. Only one from socrata or url can be. (XOR operator ^)
@@ -93,19 +93,18 @@ class Validator:
         if ('url' in source_fields) \
         else (('socrata' in source_fields) ^ ('script' in source_fields)) 
 
-    def validate_file(self, path):
+    def file_is_valid(self):
 
         # Check if path ends with a .yml file
-        extension = path.split('/')[-1].split('.')[-1]
+        extension = self.path.split('/')[-1].split('.')[-1]
         assert extension in ['yml', 'yaml'], 'Invalid file type'
 
-        f = self.__load_file(path)
-        name = path.split('/')[-1].split('.')[0]
+        name = self.path.split('/')[-1].split('.')[0]
 
         # TODO: Validate tree structure
-        assert self.tree_is_valid(f), 'Wrong fields'
-        assert self.dataset_name_matches(name, f), 'Dataset name must match file and destination name'
-        assert self.has_only_one_source(f), 'Source can only have one property from either url, socrata or script' 
+        assert self.tree_is_valid, 'Wrong fields'
+        assert self.dataset_name_matches(name), 'Dataset name must match file and destination name'
+        assert self.has_only_one_source, 'Source can only have one property from either url, socrata or script' 
                 
         return True   
 

--- a/library/validator.py
+++ b/library/validator.py
@@ -78,13 +78,13 @@ class Validator:
         return True
 
     # Check that source name matches filename and destination
-    def dataset_name_matches(self, name) -> bool:
-        dataset = self.__file['dataset']
+    def dataset_name_matches(self, name, file) -> bool:
+        dataset = file['dataset']
         return (dataset['name'] == name) and (dataset['name'] == dataset['destination']['name'])
 
     # Check that source has only one source from either url, socrata or script
-    def has_only_one_source(self):
-        dataset = self.__file['dataset']
+    def has_only_one_source(self, file):
+        dataset = file['dataset']
         source_fields = list(dataset['source'].keys())
         # In other words: if url is in source, socrata or script cannot be.
         # If url is NOT in source. Only one from socrata or url can be. (XOR operator ^)
@@ -93,17 +93,19 @@ class Validator:
         if ('url' in source_fields) \
         else (('socrata' in source_fields) ^ ('script' in source_fields)) 
 
-    def file_is_valid(self):
+    def validate_file(self, path):
 
         # Check if path ends with a .yml file
-        extension = self.path.split('/')[-1].split('.')[-1]
+        extension = path.split('/')[-1].split('.')[-1]
         assert extension in ['yml', 'yaml'], 'Invalid file type'
 
-        name = self.path.split('/')[-1].split('.')[0]
+        f = self.__load_file(path)
+        name = path.split('/')[-1].split('.')[0]
 
-        assert self.tree_is_valid, 'Wrong fields'
-        assert self.dataset_name_matches(name), 'Dataset name must match file and destination name'
-        assert self.has_only_one_source, 'Source can only have one property from either url, socrata or script' 
+        # TODO: Validate tree structure
+        assert self.tree_is_valid(f), 'Wrong fields'
+        assert self.dataset_name_matches(name, f), 'Dataset name must match file and destination name'
+        assert self.has_only_one_source(f), 'Source can only have one property from either url, socrata or script' 
                 
         return True   
 

--- a/library/validator.py
+++ b/library/validator.py
@@ -78,34 +78,32 @@ class Validator:
         return True
 
     # Check that source name matches filename and destination
-    def dataset_name_matches(self, name, file) -> bool:
-        dataset = file['dataset']
+    def dataset_name_matches(self, name) -> bool:
+        dataset = self.__file['dataset']
         return (dataset['name'] == name) and (dataset['name'] == dataset['destination']['name'])
 
     # Check that source has only one source from either url, socrata or script
-    def has_only_one_source(self, file):
-        dataset = file['dataset']
+    def has_only_one_source(self):
+        dataset = self.__file['dataset']
         source_fields = list(dataset['source'].keys())
-        # In other words: if url is in source, socrata or script cannot be.
-        # If url is NOT in source. Only one from socrata or url can be. (XOR operator ^)
+        # In other words: if url is in source, socrata or script cannot be in source.
+        # If url is NOT in source. Only one from socrata or script can be in source. (XOR operator ^)
         return \
         (('socrata' not in source_fields) and ('script' not in source_fields)) \
         if ('url' in source_fields) \
         else (('socrata' in source_fields) ^ ('script' in source_fields)) 
 
-    def validate_file(self, path):
+    def file_is_valid(self):
 
         # Check if path ends with a .yml file
-        extension = path.split('/')[-1].split('.')[-1]
+        extension = self.path.split('/')[-1].split('.')[-1]
         assert extension in ['yml', 'yaml'], 'Invalid file type'
 
-        f = self.__load_file(path)
-        name = path.split('/')[-1].split('.')[0]
-
-        # TODO: Validate tree structure
-        assert self.tree_is_valid(f), 'Wrong fields'
-        assert self.dataset_name_matches(name, f), 'Dataset name must match file and destination name'
-        assert self.has_only_one_source(f), 'Source can only have one property from either url, socrata or script' 
+        name = self.path.split('/')[-1].split('.')[0]
+       
+        assert self.tree_is_valid, 'Wrong fields'
+        assert self.dataset_name_matches(name), 'Dataset name must match file and destination name'
+        assert self.has_only_one_source, 'Source can only have one property from either url, socrata or script' 
                 
         return True   
 

--- a/library/validator.py
+++ b/library/validator.py
@@ -78,32 +78,34 @@ class Validator:
         return True
 
     # Check that source name matches filename and destination
-    def dataset_name_matches(self, name) -> bool:
-        dataset = self.__file['dataset']
+    def dataset_name_matches(self, name, file) -> bool:
+        dataset = file['dataset']
         return (dataset['name'] == name) and (dataset['name'] == dataset['destination']['name'])
 
     # Check that source has only one source from either url, socrata or script
-    def has_only_one_source(self):
-        dataset = self.__file['dataset']
+    def has_only_one_source(self, file):
+        dataset = file['dataset']
         source_fields = list(dataset['source'].keys())
-        # In other words: if url is in source, socrata or script cannot be in source.
-        # If url is NOT in source. Only one from socrata or script can be in source. (XOR operator ^)
+        # In other words: if url is in source, socrata or script cannot be.
+        # If url is NOT in source. Only one from socrata or url can be. (XOR operator ^)
         return \
         (('socrata' not in source_fields) and ('script' not in source_fields)) \
         if ('url' in source_fields) \
         else (('socrata' in source_fields) ^ ('script' in source_fields)) 
 
-    def file_is_valid(self):
+    def validate_file(self, path):
 
         # Check if path ends with a .yml file
-        extension = self.path.split('/')[-1].split('.')[-1]
+        extension = path.split('/')[-1].split('.')[-1]
         assert extension in ['yml', 'yaml'], 'Invalid file type'
 
-        name = self.path.split('/')[-1].split('.')[0]
-       
-        assert self.tree_is_valid, 'Wrong fields'
-        assert self.dataset_name_matches(name), 'Dataset name must match file and destination name'
-        assert self.has_only_one_source, 'Source can only have one property from either url, socrata or script' 
+        f = self.__load_file(path)
+        name = path.split('/')[-1].split('.')[0]
+
+        # TODO: Validate tree structure
+        assert self.tree_is_valid(f), 'Wrong fields'
+        assert self.dataset_name_matches(name, f), 'Dataset name must match file and destination name'
+        assert self.has_only_one_source(f), 'Source can only have one property from either url, socrata or script' 
                 
         return True   
 

--- a/library/validator.py
+++ b/library/validator.py
@@ -101,7 +101,6 @@ class Validator:
 
         name = self.path.split('/')[-1].split('.')[0]
 
-        # TODO: Validate tree structure
         assert self.tree_is_valid, 'Wrong fields'
         assert self.dataset_name_matches(name), 'Dataset name must match file and destination name'
         assert self.has_only_one_source, 'Source can only have one property from either url, socrata or script' 

--- a/library/validator.py
+++ b/library/validator.py
@@ -78,13 +78,13 @@ class Validator:
         return True
 
     # Check that source name matches filename and destination
-    def dataset_name_matches(self, name, file) -> bool:
-        dataset = file['dataset']
+    def dataset_name_matches(self, name) -> bool:
+        dataset = self.__file['dataset']
         return (dataset['name'] == name) and (dataset['name'] == dataset['destination']['name'])
 
     # Check that source has only one source from either url, socrata or script
-    def has_only_one_source(self, file):
-        dataset = file['dataset']
+    def has_only_one_source(self):
+        dataset = self.__file['dataset']
         source_fields = list(dataset['source'].keys())
         # In other words: if url is in source, socrata or script cannot be.
         # If url is NOT in source. Only one from socrata or url can be. (XOR operator ^)
@@ -93,19 +93,17 @@ class Validator:
         if ('url' in source_fields) \
         else (('socrata' in source_fields) ^ ('script' in source_fields)) 
 
-    def validate_file(self, path):
+    def file_is_valid(self):
 
         # Check if path ends with a .yml file
-        extension = path.split('/')[-1].split('.')[-1]
+        extension = self.path.split('/')[-1].split('.')[-1]
         assert extension in ['yml', 'yaml'], 'Invalid file type'
 
-        f = self.__load_file(path)
-        name = path.split('/')[-1].split('.')[0]
+        name = self.path.split('/')[-1].split('.')[0]
 
-        # TODO: Validate tree structure
-        assert self.tree_is_valid(f), 'Wrong fields'
-        assert self.dataset_name_matches(name, f), 'Dataset name must match file and destination name'
-        assert self.has_only_one_source(f), 'Source can only have one property from either url, socrata or script' 
+        assert self.tree_is_valid, 'Wrong fields'
+        assert self.dataset_name_matches(name), 'Dataset name must match file and destination name'
+        assert self.has_only_one_source, 'Source can only have one property from either url, socrata or script' 
                 
         return True   
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -4,14 +4,15 @@ import yaml
 
 v = Validator(f"{Path(__file__).parent}/data/test_none.yml")
 
+with open(f"{Path(__file__).parent}/data/test_none.yml", 'r') as stream:
+    f = yaml.load(stream, Loader=yaml.FullLoader)
+
+
 def test_tree_structure():
     assert v.tree_is_valid
     
 def test_dataset_name_matches():
-    assert v.dataset_name_matches('test_none')
+    assert v.dataset_name_matches('test_none', f)
 
 def test_has_only_one_source():
-    assert v.has_only_one_source
-
-def test_file_is_valid():
-    assert v.file_is_valid
+    assert v.has_only_one_source(f)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -4,15 +4,14 @@ import yaml
 
 v = Validator(f"{Path(__file__).parent}/data/test_none.yml")
 
-with open(f"{Path(__file__).parent}/data/test_none.yml", 'r') as stream:
-    f = yaml.load(stream, Loader=yaml.FullLoader)
-
-
 def test_tree_structure():
     assert v.tree_is_valid
     
 def test_dataset_name_matches():
-    assert v.dataset_name_matches('test_none', f)
+    assert v.dataset_name_matches('test_none')
 
 def test_has_only_one_source():
-    assert v.has_only_one_source(f)
+    assert v.has_only_one_source
+
+def test_file_is_valid():
+    assert v.file_is_valid

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -4,15 +4,14 @@ import yaml
 
 v = Validator(f"{Path(__file__).parent}/data/test_none.yml")
 
-with open(f"{Path(__file__).parent}/data/test_none.yml", 'r') as stream:
-    f = yaml.load(stream, Loader=yaml.FullLoader)
-
-
 def test_tree_structure():
     assert v.tree_is_valid
     
 def test_dataset_name_matches():
-    assert v.dataset_name_matches('test_none', f)
+    assert v.dataset_name_matches('test_none')
 
 def test_has_only_one_source():
-    assert v.has_only_one_source(f)
+    assert v.has_only_one_source
+
+def test_validate_file():
+    assert v.file_is_valid

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2,14 +2,14 @@ from pathlib import Path
 from library.validator import Validator
 import yaml
 
-v = Validator()
+v = Validator(f"{Path(__file__).parent}/data/test_none.yml")
 
 with open(f"{Path(__file__).parent}/data/test_none.yml", 'r') as stream:
     f = yaml.load(stream, Loader=yaml.FullLoader)
 
 
 def test_tree_structure():
-    assert v.tree_is_valid(f)
+    assert v.tree_is_valid
     
 def test_dataset_name_matches():
     assert v.dataset_name_matches('test_none', f)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -4,14 +4,15 @@ import yaml
 
 v = Validator(f"{Path(__file__).parent}/data/test_none.yml")
 
+with open(f"{Path(__file__).parent}/data/test_none.yml", 'r') as stream:
+    f = yaml.load(stream, Loader=yaml.FullLoader)
+
+
 def test_tree_structure():
     assert v.tree_is_valid
     
 def test_dataset_name_matches():
-    assert v.dataset_name_matches('test_none')
+    assert v.dataset_name_matches('test_none', f)
 
 def test_has_only_one_source():
-    assert v.has_only_one_source
-
-def test_validate_file():
-    assert v.file_is_valid
+    assert v.has_only_one_source(f)


### PR DESCRIPTION
Part of issue #106 

File is loaded in constructor and checks can be called as properties without parameters (Except for dataset_name_matches(name)). Renamed validate_file check to file_is_valid for readability when it's called.

To do next: assert correct file extension (.yml or .yaml) in constructor. This way the validator cannot be instantiated without a proper file path. Also, get file name as a property so it can be removed from dataset_name_matches

PD: I initially committed and pull request was not showing up. I reverted and push again until PR showed again. Apologize for the many  commits