### PR TITLE
Integrating validator methods into config

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -82,88 +82,82 @@ class Config:
 
         # Validate unparsed, unrendered file
         v = Validator(self.parsed_unrendered_template)
+        v()
 
-        # If validation passes, parse the config file
-        if v():
-            if self.source_type == "script":
-                if self.version:
-                    version = self.version
-                else:
-                    version = self.version_today
-                config = self.parsed_rendered_template(version=version)
-                _config = self.parsed_unrendered_template
+        if self.source_type == "script":
+            if self.version:
+                version = self.version
+            else:
+                version = self.version_today
+            config = self.parsed_rendered_template(version=version)
+            _config = self.parsed_unrendered_template
 
-                script_name = _config["dataset"]["source"]["script"]
-                module = importlib.import_module(f"library.script.{script_name}")
-                scriptor = module.Scriptor()
-                url = scriptor.runner()
+            script_name = _config["dataset"]["source"]["script"]
+            module = importlib.import_module(f"library.script.{script_name}")
+            scriptor = module.Scriptor()
+            url = scriptor.runner()
 
-                options = config["dataset"]["source"]["options"]
-                geometry = config["dataset"]["source"]["geometry"]
-                config["dataset"]["source"] = {
-                    "url": {"path": url, "subpath": ""},
-                    "options": options,
-                    "geometry": geometry,
-                }
+            options = config["dataset"]["source"]["options"]
+            geometry = config["dataset"]["source"]["geometry"]
+            config["dataset"]["source"] = {
+                "url": {"path": url, "subpath": ""},
+                "options": options,
+                "geometry": geometry,
+            }
 
-            if self.source_type == "url":
-                # Load unrendered template to check for yml-specified
-                # version (_version)
-                _config = self.parsed_unrendered_template
-                _version = _config["dataset"]["version"]
+        if self.source_type == "url":
+            # Load unrendered template to check for yml-specified
+            # version (_version)
+            _config = self.parsed_unrendered_template
+            _version = _config["dataset"]["version"]
 
-                # If a custom version specified from CLI, take custom version
-                if self.version:
-                    version = self.version
+            # If a custom version specified from CLI, take custom version
+            if self.version:
+                version = self.version
 
-                # If no custom version specified and version in config
-                # is valid, take config version (_version)
-                if not self.version and self.valid_version(_version):
-                    version = _version
+            # If no custom version specified and version in config
+            # is valid, take config version (_version)
+            if not self.version and self.valid_version(_version):
+                version = _version
 
-                # If no custom version and no config version,
-                # assign today as version
-                if not self.version and not self.valid_version(_version):
-                    version = self.version_today
+            # If no custom version and no config version,
+            # assign today as version
+            if not self.version and not self.valid_version(_version):
+                version = self.version_today
 
-                # Render template
-                config = self.parsed_rendered_template(version=version)
+            # Render template
+            config = self.parsed_rendered_template(version=version)
 
-                # Force overwrite of yml version with appropriate version
-                config["dataset"]["version"] = version
+            # Force overwrite of yml version with appropriate version
+            config["dataset"]["version"] = version
 
-            if self.source_type == "socrata":
-                # For socrata we are computing the url and add the url object to the config file
-                _uid = self.parsed_unrendered_template["dataset"]["source"]["socrata"][
-                    "uid"
-                ]
-                _format = self.parsed_unrendered_template["dataset"]["source"][
-                    "socrata"
-                ]["format"]
-                config = self.parsed_rendered_template(
-                    version=self.version_socrata(_uid)
-                )
+        if self.source_type == "socrata":
+            # For socrata we are computing the url and add the url object to the config file
+            _uid = self.parsed_unrendered_template["dataset"]["source"]["socrata"][
+                "uid"
+            ]
+            _format = self.parsed_unrendered_template["dataset"]["source"]["socrata"][
+                "format"
+            ]
+            config = self.parsed_rendered_template(version=self.version_socrata(_uid))
 
-                if _format == "csv":
-                    url = f"https://data.cityofnewyork.us/api/views/{_uid}/rows.csv"
-                if _format == "geojson":
-                    url = f"https://nycopendata.socrata.com/api/geospatial/{_uid}?method=export&format=GeoJSON"
+            if _format == "csv":
+                url = f"https://data.cityofnewyork.us/api/views/{_uid}/rows.csv"
+            if _format == "geojson":
+                url = f"https://nycopendata.socrata.com/api/geospatial/{_uid}?method=export&format=GeoJSON"
 
-                options = config["dataset"]["source"]["options"]
-                geometry = config["dataset"]["source"]["geometry"]
-                config["dataset"]["source"] = {
-                    "url": {"path": url, "subpath": ""},
-                    "options": options,
-                    "geometry": geometry,
-                }
+            options = config["dataset"]["source"]["options"]
+            geometry = config["dataset"]["source"]["geometry"]
+            config["dataset"]["source"] = {
+                "url": {"path": url, "subpath": ""},
+                "options": options,
+                "geometry": geometry,
+            }
 
-            path = config["dataset"]["source"]["url"]["path"]
-            subpath = config["dataset"]["source"]["url"]["subpath"]
-            config["dataset"]["source"]["url"]["gdalpath"] = format_url(path, subpath)
-            return config
-
-        # If validation doesn't pass, return nothing
-        return None
+        path = config["dataset"]["source"]["url"]["path"]
+        subpath = config["dataset"]["source"]["url"]["subpath"]
+        config["dataset"]["source"]["url"]["gdalpath"] = format_url(path, subpath)
+        return config
 
     @property
     def compute_json(self) -> str:
@@ -182,10 +176,8 @@ class Config:
     @property
     def compute_parsed(self) -> (dict, dict, dict, dict):
         config = self.compute
-        if config:
-            dataset = config["dataset"]
-            source = dataset["source"]
-            destination = dataset["destination"]
-            info = dataset["info"]
-            return dataset, source, destination, info
-        return None
+        dataset = config["dataset"]
+        source = dataset["source"]
+        destination = dataset["destination"]
+        info = dataset["info"]
+        return dataset, source, destination, info

--- a/library/config.py
+++ b/library/config.py
@@ -81,8 +81,7 @@ class Config:
         """based on given yml file, compute the configuration"""
 
         # Validate unparsed, unrendered file
-        v = Validator(self.parsed_unrendered_template)
-        v()
+        Validator(self.parsed_unrendered_template)()
 
         if self.source_type == "script":
             if self.version:

--- a/library/validator.py
+++ b/library/validator.py
@@ -73,72 +73,21 @@ class Validator:
     the library.
     """
 
-    def __init__(self, path):
+    def __init__(self, f):
+        self.__unparsed_file = f
 
-        # Abort if file path is not valid
-        if not self.__check_extension(path):
-            raise Exception("File path must point to a .yml or .yaml file")
-
-        self.path = path
-        self.fname = path.split("/")[-1].split(".")[0]
-
-    def __check_extension(self, path):
-        # Check if path ends with a .yml file
-        extension = path.split("/")[-1].split(".")[-1]
-        return extension in ["yml", "yaml"]
-
-    @cached_property
-    def __file(self):
-        with open(self.path, "r") as stream:
-            y = yaml.load(stream, Loader=yaml.FullLoader)
-            return y
+    def __call__(self):
+        return self.file_is_valid
 
     @property
     def tree_is_valid(self) -> bool:
-        if self.__file["dataset"] == None:
-            return False
-
-        try:
-            input_ds = Dataset(**self.__file["dataset"])
-
-        except ValidationError as e:
-            print(e.json())
-            return False
-
         return True
-
-    # Check that source name matches filename and destination
-    @property
-    def dataset_name_matches(self) -> bool:
-        dataset = self.__file["dataset"]
-        return (dataset["name"] == self.fname) and (
-            dataset["name"] == dataset["destination"]["name"]
-        )
 
     # Check that source has only one source from either url, socrata or script
     @property
     def has_only_one_source(self):
-        dataset = self.__file["dataset"]
-        source_fields = list(dataset["source"].keys())
-        # In other words: if url is in source, socrata or script cannot be.
-        # If url is NOT in source. Only one from socrata or url can be. (XOR operator ^)
-        return (
-            (("socrata" not in source_fields) and ("script" not in source_fields))
-            if ("url" in source_fields)
-            else (("socrata" in source_fields) ^ ("script" in source_fields))
-        )
+        return True
 
     @property
     def file_is_valid(self):
-
-        name = self.path.split("/")[-1].split(".")[0]
-
-        assert self.tree_is_valid, "Wrong fields"
-        assert (
-            self.dataset_name_matches
-        ), "Dataset name must match file and destination name"
-        assert (
-            self.has_only_one_source
-        ), "Source can only have one property from either url, socrata or script"
-
         return True

--- a/library/validator.py
+++ b/library/validator.py
@@ -79,8 +79,14 @@ class Validator:
     def __call__(self):
         return self.file_is_valid
 
+    # Check that the tree structure fits the specified schema
     @property
     def tree_is_valid(self) -> bool:
+        return True
+
+    # Check that the dataset name matches with destination name
+    @property
+    def dataset_name_matches(self):
         return True
 
     # Check that source has only one source from either url, socrata or script
@@ -88,6 +94,7 @@ class Validator:
     def has_only_one_source(self):
         return True
 
+    # Assert all the individual checks
     @property
     def file_is_valid(self):
         return True

--- a/library/validator.py
+++ b/library/validator.py
@@ -77,7 +77,7 @@ class Validator:
         self.__unparsed_file = f
 
     def __call__(self):
-        return self.file_is_valid
+        assert self.file_is_valid
 
     # Check that the tree structure fits the specified schema
     @property

--- a/library/validator.py
+++ b/library/validator.py
@@ -74,7 +74,7 @@ class Validator:
     """
 
     def __init__(self, f):
-        self.__unparsed_file = f
+        self.__parsed_file = f
 
     def __call__(self):
         assert self.tree_is_valid, "Some fields are not valid. Please review your file"
@@ -88,10 +88,10 @@ class Validator:
     # Check that the tree structure fits the specified schema
     @property
     def tree_is_valid(self) -> bool:
-        if self.__unparsed_file["dataset"] == None:
+        if self.__parsed_file["dataset"] == None:
             return False
         try:
-            input_ds = Dataset(**self.__unparsed_file["dataset"])
+            input_ds = Dataset(**self.__parsed_file["dataset"])
         except ValidationError as e:
             print(e.json())
             return False
@@ -100,13 +100,13 @@ class Validator:
     # Check that the dataset name matches with destination name
     @property
     def dataset_name_matches(self):
-        dataset = self.__unparsed_file["dataset"]
+        dataset = self.__parsed_file["dataset"]
         return dataset["name"] == dataset["destination"]["name"]
 
     # Check that source has only one source from either url, socrata or script
     @property
     def has_only_one_source(self):
-        dataset = self.__unparsed_file["dataset"]
+        dataset = self.__parsed_file["dataset"]
         source_fields = list(dataset["source"].keys())
         # In other words: if url is in source, socrata or script cannot be.
         # If url is NOT in source. Only one from socrata or url can be. (XOR operator ^)

--- a/library/validator.py
+++ b/library/validator.py
@@ -77,7 +77,9 @@ class Validator:
         self.__unparsed_file = f
 
     def __call__(self):
-        assert self.file_is_valid
+        assert self.tree_is_valid
+        assert self.dataset_name_matches
+        assert self.has_only_one_source
 
     # Check that the tree structure fits the specified schema
     @property
@@ -92,9 +94,4 @@ class Validator:
     # Check that source has only one source from either url, socrata or script
     @property
     def has_only_one_source(self):
-        return True
-
-    # Assert all the individual checks
-    @property
-    def file_is_valid(self):
         return True

--- a/tests/data/socrata.yml
+++ b/tests/data/socrata.yml
@@ -1,6 +1,7 @@
 dataset:
   name: &name dpr_parksproperties
   version: "{{ version }}"
+  acl: public-read
   source:
     # if source is socrata, the url can be computed
     socrata:

--- a/tests/data/url.yml
+++ b/tests/data/url.yml
@@ -1,7 +1,7 @@
 dataset:
   name: &name dcp_mappluto
   version: "{{ version }}"
-  acl: public
+  acl: public-read
   # Source definition
   source:
     url:

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -4,7 +4,8 @@ import yaml
 
 from library.validator import Validator
 
-v = Validator(f"{Path(__file__).parent}/data/test_none.yml")
+with open(f"{Path(__file__).parent}/data/test_none.yml", "r") as f:
+    v = Validator(yaml.safe_load(f.read()))
 
 
 def test_tree_structure():

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -17,7 +17,3 @@ def test_dataset_name_matches():
 
 def test_has_only_one_source():
     assert v.has_only_one_source
-
-
-def test_file_is_valid():
-    assert v.file_is_valid

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -11,10 +11,6 @@ def test_tree_structure():
     assert v.tree_is_valid
 
 
-def test_dataset_name_matches():
-    assert v.dataset_name_matches
-
-
 def test_has_only_one_source():
     assert v.has_only_one_source
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -11,6 +11,10 @@ def test_tree_structure():
     assert v.tree_is_valid
 
 
+def test_dataset_name_matches():
+    assert v.dataset_name_matches
+
+
 def test_has_only_one_source():
     assert v.has_only_one_source
 


### PR DESCRIPTION
Part of #129. I made a partial version of validator to return true on all checks. Called validator in `config.compute()`. If `validator()` returns true, compute proceeds to parse the unrendered file. Otherwise, compute returns `None`.

The new version of validator will take an already parsed yml file 