### PR TITLE
Devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM osgeo/gdal:ubuntu-small-3.2.1
+
+RUN apt update && apt install -y python3-pip python3-distutils git
+
+RUN adduser --disabled-password --gecos '' vscode
+
+USER vscode
+
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+
+ENV PATH="~/.poetry/bin:$PATH"
+
+ENV PATH="~/.local/bin:$PATH"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,9 @@
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
 	"postCreateCommand": ". $HOME/.poetry/env && poetry install",
 
+	// Adding id_rsa so that we can push to github from the dev container
+	"initializeCommand": "ssh-add $HOME/.ssh/id_rsa",
+
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.163.1/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": null
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": ["ms-python.python"],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	"postCreateCommand": ". $HOME/.poetry/env && poetry install",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
For local vscode development, we can use the devcontainer configuration file to spin up a dev environment in docker locally.
![image](https://user-images.githubusercontent.com/13207770/112359845-13d43200-8ca8-11eb-8220-ebcea18fac4d.png)
Select open folder in container will allow vscode to create a docker image with given dependencies and copy the directory into the devcontainer so that we have an insolated environment (with gdal, git, poetry enabled) locally

Note: the default git ssh private key is `~/.ssh/id_rsa`, you can change it to another file if needed