### PR TITLE
FacDB URL sources

### DIFF
--- a/library/templates/nysdec_lands.yml
+++ b/library/templates/nysdec_lands.yml
@@ -1,0 +1,32 @@
+dataset:
+  name: &name nysdec_lands
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://gisservices.its.ny.gov/arcgis/rest/services/dec_lands/MapServer/0/query?where=1=1&outfields=*&f=geojson
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: MULTIPOLYGON
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: MULTIPOLYGON
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## DEC Lands and Campgrounds
+      Lands under the care, custody and control of DEC, including Wildlife Management areas, Unique Areas, State Forests, Forest Preserve, and DEC-operated campgrounds.
+    url: http://gis.ny.gov/gisdata/inventories/details.cfm?DSID=1114
+    dependents: []

--- a/library/templates/nysdec_solidwaste.yml
+++ b/library/templates/nysdec_solidwaste.yml
@@ -1,0 +1,32 @@
+dataset:
+  name: &name nysdec_solidwaste
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://data.ny.gov/api/views/2fni-raj8/rows.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## Solid Waste Management Facilities
+      Active Solid Waste Management Facilities
+    url: https://data.ny.gov/Energy-Environment/Solid-Waste-Management-Facilities/2fni-raj8
+    dependents: []

--- a/library/templates/nysdec_solidwaste.yml
+++ b/library/templates/nysdec_solidwaste.yml
@@ -10,13 +10,13 @@ dataset:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
 
   destination:
     name: *name
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
     options:
       - "OVERWRITE=YES"

--- a/library/templates/nysdoh_healthfacilities.yml
+++ b/library/templates/nysdoh_healthfacilities.yml
@@ -1,0 +1,32 @@
+dataset:
+  name: &name nysdoh_healthfacilities
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://health.data.ny.gov/api/views/vn5v-hh5r/rows.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## Health Facility General Information
+      This dataset contains the locations of Article 28, Article 36 and Article 40 health care facilities and programs from the Health Facilities Information System (HFIS). Article 28 facilities are hospitals, nursing homes, diagnostic treatment centers and midwifery birth centers. Article 36 facilities are certified home health care agencies, licensed home care services agencies, and long term home health care programs. Article 40 facilities are hospices. The dataset currently only contains the locations of hospitals and hospital extension clinics. The data for the remaining facility types will be added in the future.
+    url: https://health.data.ny.gov/Health/Health-Facility-General-Information/vn5v-hh5r
+    dependents: []

--- a/library/templates/nysdoh_healthfacilities.yml
+++ b/library/templates/nysdoh_healthfacilities.yml
@@ -10,13 +10,13 @@ dataset:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
 
   destination:
     name: *name
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
     options:
       - "OVERWRITE=YES"

--- a/library/templates/nysdoh_nursinghomes.yml
+++ b/library/templates/nysdoh_nursinghomes.yml
@@ -1,0 +1,34 @@
+dataset:
+  name: &name nysdoh_nursinghomes
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://health.data.ny.gov/api/views/izta-vnpq/rows.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## Nursing Home Weekly Bed Census: Last Submission
+      The Department of Health requires nursing homes to complete electronic filing of each facility's licensed nursing home beds and availability by bed category on a weekly basis. All nursing homes are requested to submit their Weekly Bed Census between Wednesday and Friday of each week, based on the census at 12:00 AM on Wednesday night.
+
+      The Nursing Home Weekly Bed Census data is the most recent data available.
+    url: https://health.data.ny.gov/Health/Nursing-Home-Weekly-Bed-Census-Last-Submission/izta-vnpq
+    dependents: []

--- a/library/templates/nysdoh_nursinghomes.yml
+++ b/library/templates/nysdoh_nursinghomes.yml
@@ -10,13 +10,13 @@ dataset:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
 
   destination:
     name: *name
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
     options:
       - "OVERWRITE=YES"

--- a/library/templates/nysoasas_programs.yml
+++ b/library/templates/nysoasas_programs.yml
@@ -1,0 +1,31 @@
+dataset:
+  name: &name nysoasas_programs
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://webapps.oasas.ny.gov/providerDirectory/download/Treatment_Providers_OASAS_Directory_Search_{{ version }}.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## Chemical Dependence Treatment Programs
+    url: https://webapps.oasas.ny.gov/providerDirectory/index.cfm?search_type=2
+    dependents: []

--- a/library/templates/nysoasas_programs.yml
+++ b/library/templates/nysoasas_programs.yml
@@ -10,13 +10,13 @@ dataset:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
 
   destination:
     name: *name
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
     options:
       - "OVERWRITE=YES"

--- a/library/templates/nysopwdd_providers.yml
+++ b/library/templates/nysopwdd_providers.yml
@@ -1,0 +1,43 @@
+dataset:
+  name: &name nysopwdd_providers
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://data.ny.gov/api/views/ieqx-cqyk/rows.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## Directory of Developmental Disabilities Service Provider Agencies
+      The dataset contains the address and phone number information for Voluntary Sector providers of the following OPWDD supports and services:
+      + INTERMEDIATE CARE FACILITIES (ICF);
+      + INDIVIDUAL RESIDENTIAL ALTERNATIVE (IRA);
+      + FAMILY CARE;
+      + SELF-DIRECTION SERVICES;
+      + INDIVIDUAL SUPPORT SERVICES (ISS);
+      + DAY HABILITATION;
+      + PREVOCATIONAL;
+      + SUPPORTED EMPLOYMENT ENROLLMENTS;
+      + COMMUNITY HABILITATION;
+      + FAMILY SUPPORT SERVICES;
+      + DEVELOPMENTAL CENTERS AND SPECIAL POPULATION SERVICES.
+    url: https://data.ny.gov/Human-Services/Directory-of-Developmental-Disabilities-Service-Pr/ieqx-cqyk
+    dependents: []

--- a/library/templates/nysopwdd_providers.yml
+++ b/library/templates/nysopwdd_providers.yml
@@ -10,13 +10,13 @@ dataset:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
 
   destination:
     name: *name
     geometry:
-      SRS: EPSG:4326
+      SRS: null
       type: NONE
     options:
       - "OVERWRITE=YES"

--- a/library/templates/nysparks_historicplaces.yml
+++ b/library/templates/nysparks_historicplaces.yml
@@ -21,6 +21,8 @@ dataset:
     options:
       - "OVERWRITE=YES"
       - "PRECISION=NO"
+      - "X_POSSIBLE_NAMES=longitude,Longitude,Lon,lon,x"
+      - "Y_POSSIBLE_NAMES=latitude,Latitude,Lat,lat,y"
     fields: []
     sql: null
 

--- a/library/templates/nysparks_historicplaces.yml
+++ b/library/templates/nysparks_historicplaces.yml
@@ -1,0 +1,34 @@
+dataset:
+  name: &name nysparks_historicplaces
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://data.ny.gov/api/views/iisn-hnyv/rows.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## National Register of Historic Places
+      The New York State Office of Parks, Recreation and Historic Preservation (OPRHP) oversees more than 250 state parks, historic sites, recreational trails, golf courses, boat launches and more, encompassing nearly 350,000 acres, that are visited by 74 million people annually. These facilities contribute to the economic vitality and quality of life of local communities and directly support New York’s tourism industry. Parks also provide a place for families and children to be active and exercise, promoting healthy lifestyles. The agency is responsible for the operation and stewardship of the state park system as well as advancing a statewide parks, historic preservation, and open space mission.
+
+      The New York State Historic Preservation Office maintains the list of New York State’s National Register of Historic Places. The National Register of Historic Places is the official list of the Nation's historic places worthy of preservation. Authorized by the National Historic Preservation Act of 1966 ( Federal Regulation 36 CFR 60 ) the National Park Service's National Register of Historic Places is part of a national program to coordinate and support public and private efforts to identify, evaluate, and protect America's historic and archeological resources. To be considered eligible, a building, district, structure or object must meet the National Register Criteria for Evaluation. This involves examining the property’s age, integrity, and significance. Please see metadata for additional information, including how to access the agency’s Cultural Resource Information System (CRIS) which provides access to the agency’s database of historic records associated with each project listing in this dataset.
+    url: https://data.ny.gov/Recreation/National-Register-of-Historic-Places/iisn-hnyv
+    dependents: []

--- a/library/templates/nysparks_parks.yml
+++ b/library/templates/nysparks_parks.yml
@@ -21,6 +21,8 @@ dataset:
     options:
       - "OVERWRITE=YES"
       - "PRECISION=NO"
+      - "X_POSSIBLE_NAMES=longitude,Longitude,Lon,lon,x"
+      - "Y_POSSIBLE_NAMES=latitude,Latitude,Lat,lat,y"
     fields: []
     sql: null
 

--- a/library/templates/nysparks_parks.yml
+++ b/library/templates/nysparks_parks.yml
@@ -1,0 +1,32 @@
+dataset:
+  name: &name nysparks_parks
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://data.ny.gov/api/views/9uuk-x7vh/rows.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## State Park Facility Points
+      The New York State Office of Parks, Recreation and Historic Preservation (OPRHP) oversees more than 250 state parks, historic sites, recreational trails, golf courses, boat launches and more, encompassing nearly 350,000 acres, that are visited by 74 million people annually. These facilities contribute to the economic vitality and quality of life of local communities and directly support New York’s tourism industry. Parks also provide a place for families and children to be active and exercise, promoting healthy lifestyles. The agency is responsible for the operation and stewardship of the state park system as well as advancing a statewide parks, historic preservation, and open space mission.
+    url: https://data.ny.gov/Recreation/State-Park-Facility-Points/9uuk-x7vh
+    dependents: []

--- a/library/templates/usdot_airports.yml
+++ b/library/templates/usdot_airports.yml
@@ -1,0 +1,32 @@
+dataset:
+  name: &name usdot_airports
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://opendata.arcgis.com/datasets/831853ab8b714a81b6a3e21d0b164a4e_0.geojson
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## Airports
+      The Airports dataset includes all official and operational aerodromes as of July 16, 2020 and is part of the U.S. Department of Transportation (USDOT)/Bureau of Transportation Statistics (BTS) National Transportation Atlas Database (NTAD). The Airports database is a geographic point database of official operational aerodromes in the United States and U.S. Territories. Attribute data is provided on the physical and operational characteristics of the aerodrome, current usage including enplanements and aircraft operations, congestion levels and usage categories. This geospatial data is derived from the FAA's National Airspace System Resource Aeronautical Data Product.
+    url: https://hub.arcgis.com/datasets/usdot::airports
+    dependents: []

--- a/library/templates/usdot_ports.yml
+++ b/library/templates/usdot_ports.yml
@@ -26,7 +26,7 @@ dataset:
 
   info:
     description: |
-      ## DEC Lands and Campgrounds
+      ## Ports
       The Ports dataset is part of the U.S. Department of Transportation (USDOT)/Bureau of Transportation Statistics's (BTS's) National Transportation Atlas Database (NTAD). Contains physical information on commercial facilities at U.S. Coastal, Great Lakes and Inland Ports. The data consists of location description, street address, city, county name, congressional district FIPS code, type of construction, cargo-handling equipment, water depth alongside the facility, facility type ( dock, fleeting area, lock and/or dam) berthing space, latitude, longitude, current operators and owner's information, list of commodities handled at facility, road/railway connections, equipment available at facility, storage facilities, cranes, transit sheds, grain elevators, marine repair plants, fleeting areas, and docking, and facility start/stop date.
     url: https://hub.arcgis.com/datasets/usdot::ports
     dependents: []

--- a/library/templates/usdot_ports.yml
+++ b/library/templates/usdot_ports.yml
@@ -1,0 +1,32 @@
+dataset:
+  name: &name usdot_ports
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://opendata.arcgis.com/datasets/d824e107008942558881bc598b05c60b_0.geojson
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## DEC Lands and Campgrounds
+      The Ports dataset is part of the U.S. Department of Transportation (USDOT)/Bureau of Transportation Statistics's (BTS's) National Transportation Atlas Database (NTAD). Contains physical information on commercial facilities at U.S. Coastal, Great Lakes and Inland Ports. The data consists of location description, street address, city, county name, congressional district FIPS code, type of construction, cargo-handling equipment, water depth alongside the facility, facility type ( dock, fleeting area, lock and/or dam) berthing space, latitude, longitude, current operators and owner's information, list of commodities handled at facility, road/railway connections, equipment available at facility, storage facilities, cranes, transit sheds, grain elevators, marine repair plants, fleeting areas, and docking, and facility start/stop date.
+    url: https://hub.arcgis.com/datasets/usdot::ports
+    dependents: []


### PR DESCRIPTION
#138 

Currently, nysoasas_programs requires specifying current date in the form dd-Mon-yy:
Example usage:
`poetry run library archive -s -c -l -v 01-Apr-21 -n nysoasas_programs`

There might be a way of formatting current date to be able to use the default version as an enhancement.