### PR TITLE
Update Pluto source table config

### DIFF
--- a/library/templates/dsny_frequencies.yml
+++ b/library/templates/dsny_frequencies.yml
@@ -9,8 +9,7 @@ dataset:
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
-      - "X_POSSIBLE_NAMES=longitude,Longitude,Lon,lon,x"
-      - "Y_POSSIBLE_NAMES=latitude,Latitude,Lat,lat,y"
+      - "GEOM_POSSIBLE_NAMES=multipolygon"
     geometry:
       SRS: EPSG:4326
       type: NONE

--- a/library/templates/lpc_historic_districts.yml
+++ b/library/templates/lpc_historic_districts.yml
@@ -9,8 +9,7 @@ dataset:
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
-      - "X_POSSIBLE_NAMES=longitude,Longitude,Lon,lon,x"
-      - "Y_POSSIBLE_NAMES=latitude,Latitude,Lat,lat,y"
+      - "GEOM_POSSIBLE_NAMES=the_geom"
     geometry:
       SRS: EPSG:4326
       type: NONE

--- a/library/templates/lpc_landmarks.yml
+++ b/library/templates/lpc_landmarks.yml
@@ -9,8 +9,7 @@ dataset:
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
-      - "X_POSSIBLE_NAMES=longitude,Longitude,Lon,lon,x"
-      - "Y_POSSIBLE_NAMES=latitude,Latitude,Lat,lat,y"
+      - "GEOM_POSSIBLE_NAMES=the_geom"
     geometry:
       SRS: EPSG:4326
       type: NONE


### PR DESCRIPTION
these tables have geometry columns instead of lat lon, so we need to use geom_possible_name
also we need to make sure that they have sql pgdump file included in the latest folder, otherwise, pluto cannot pick it up (e.g. parks property and dpr_greenthumb)