### PR TITLE
adding a bash wrapper for db-data-library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 
 # library output folder
 .library
+.config

--- a/library.sh
+++ b/library.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+function init {
+    UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)
+    docker build . -t library:$UUID
+    echo "$UUID" > .config
+}
+
+function library_execute {
+    if [ ! -f .config ]; then
+        echo "run ./library.sh init first to initialize"
+    else
+        UUID=$(cat .config)
+        docker run --rm --tty --env-file .env\
+            -u $(id -u ${USER}):$(id -g ${USER})\
+            -v $(pwd):/library library:$UUID library $@
+    fi
+}
+
+case $1 in
+    init) init ;;
+    *) library_execute $@;;
+esac


### PR DESCRIPTION
the bash wrapper works for all python cli commands, 
all we have to do is to run 
`./library init` to initialize docker container 
then we can replace all `library` with `./library.sh` to run commands normally
This PR is aimed to retire DO code-server in favor of local devcontainer and google cloud shell dev environment