### PR TITLE
Update Poetry Version in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ RUN adduser --disabled-password --gecos '' vscode
 
 USER vscode
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_VERSION=1.1.6 python3 -
 
 ENV PATH="~/.poetry/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /library/
 
 RUN apt update && apt install -y python3-pip python3-distutils
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_VERSION=1.1.6 python3 -
 
 RUN . $HOME/.poetry/env;\
     poetry config virtualenvs.create false --local;\


### PR DESCRIPTION
Specify that poetry 1.1.6 should be installed in container. Fixed bug where gdal installation in container was failing on build. 