### PR TITLE
Change yml files to match convention

### DIFF
--- a/library/templates/dot_projects_bridges.yml
+++ b/library/templates/dot_projects_bridges.yml
@@ -4,8 +4,8 @@ dataset:
   acl: private
   source:
     url:
-      path: April_2021/BridgeProjects_Apr2021Plan_Planned.shp
-      subpath: ""
+      path: library/tmp/DOTBridges.zip
+      subpath: DOTBridges.shp
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"

--- a/library/templates/edc_capitalprojects.yml
+++ b/library/templates/edc_capitalprojects.yml
@@ -4,8 +4,8 @@ dataset:
   acl: private
   source:
     url:
-      path: CCP_April21_EDC/CCP_April21_EDC.shp
-      subpath: ""
+      path: library/tmp/EDCCapital.zip
+      subpath: EDCCapital.shp
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"


### PR DESCRIPTION
#190 We receive four spatial datasets from DOT, DDC, EDC via email. Refactor yml files so that they remain consistent and are downloaded using the similar tmp method 