### PR TITLE
Traffic Injuries and Fatalities

### DIFF
--- a/library/templates/dcp_dot_trafficinjuries.yml
+++ b/library/templates/dcp_dot_trafficinjuries.yml
@@ -1,0 +1,34 @@
+dataset:
+  name: &name dcp_dot_trafficinjuries
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: library/tmp/crash{{ version }}.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: null
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ###  DCP Transportation Traffic Injuries
+      Input for EDDT. Includes number of total injuries from crashes, pedestrian injuries,
+      cyclist injuries, motorist injuries, and total fatalities by PUMA (public use microdata area).
+
+    url:
+    dependents: []


### PR DESCRIPTION
New dataset name is dcp_dot_trafficinjuries. Think this is better than crashes as pedestrians getting hit by cars isn't really a "crash" to me. Plus not all crashes result in injuries. 
Files are in https://cloud.digitalocean.com/spaces/edm-recipes?i=266877&path=datasets%2Fdcp_dot_trafficinjuries%2F