### PR TITLE
change nysdec_lands url to the new shapefile

### DIFF
--- a/library/templates/nysdec_lands.yml
+++ b/library/templates/nysdec_lands.yml
@@ -10,7 +10,7 @@ dataset:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:4326
+      SRS: EPSG:2263
       type: MULTIPOLYGON
 
   destination:

--- a/library/templates/nysdec_lands.yml
+++ b/library/templates/nysdec_lands.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://gisservices.its.ny.gov/arcgis/rest/services/dec_lands/MapServer/0/query?where=1=1&outfields=*&f=geojson
+      path: http://gis.ny.gov/gisdata/data/ds_1114/DEC_lands.zip
       subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"

--- a/library/templates/nysdec_lands.yml
+++ b/library/templates/nysdec_lands.yml
@@ -10,7 +10,7 @@ dataset:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:2263
+      SRS: EPSG:26918
       type: MULTIPOLYGON
 
   destination:


### PR DESCRIPTION
Refer #221 for the descriotion of the issue

change the workflow for nysdec_lands to point the new location of the shapefile. The existing process handles the change nicely even though the file format changes from a geojson to a zip shapefile on the remote address.

It is worth noting that the new version of this file does not include some of those records in the previous versions such as the campgrounds which cause the archived csv to be smaller in size compared to the previous versions. It was tested in the loading process with facdb that this won't be an issue where campgrounds are not included in the final facdb anyway. The last version compared to the 20220421 version increases the number of records from 26 to 27 in facdb for this source data. 