### PR TITLE
Change path for some manual upload datasets

### DIFF
--- a/library/templates/foodbankny_foodbanks.yml
+++ b/library/templates/foodbankny_foodbanks.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: "Food Bank For NYC Open Members as of 4921.kml"
+      path: "Food_Bank_For_NYC_Open_Members_as_of_4622.csv"
       subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"

--- a/library/templates/nysdec_lands.yml
+++ b/library/templates/nysdec_lands.yml
@@ -4,8 +4,8 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://gisservices.its.ny.gov/arcgis/rest/services/dec_lands/MapServer/0/query?where=1=1&outfields=*&f=geojson
-      subpath: ""
+      path:  http://gis.ny.gov/gisdata/data/ds_1114/DEC_lands.zip
+      subpath: "DecLands.shp"
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"

--- a/library/templates/nysdec_lands.yml
+++ b/library/templates/nysdec_lands.yml
@@ -4,13 +4,13 @@ dataset:
   acl: public-read
   source:
     url:
-      path:  http://gis.ny.gov/gisdata/data/ds_1114/DEC_lands.zip
-      subpath: "DecLands.shp"
+      path: http://gis.ny.gov/gisdata/data/ds_1114/DEC_lands.zip
+      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:4326
+      SRS: EPSG:26918
       type: MULTIPOLYGON
 
   destination:

--- a/library/templates/nysed_activeinstitutions.yml
+++ b/library/templates/nysed_activeinstitutions.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: library/tmp/All Institutions_ Active Institutions with GIS coordinates and OITS Accuracy Code - Select by County.csv
+      path: library/tmp/All_Institutions_by_County.csv
       subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"


### PR DESCRIPTION
I uploaded three datasets for the [dataloading step of the 2022 Q1 build of facDB](https://github.com/NYCPlanning/db-facilities/issues/526) that required tweaking the upload process in data library. 
 - `nysdec_lands` data is now posted online as a shapefile instead of a geojson and the path in the corresponding template reflects this
 - `foodbanknyc_foodbanks` now reads a .csv instead of a .kml as per the instructions in the wiki
 - `nysed_activeinstitutions` now points to a file with the same name it's downloaded as
None of these changes are vital, but in a situation where the data doesn't change for the next build then we can use these templates again