### PR TITLE
New template for dcp_facilities_with_unmapped

### DIFF
--- a/library/script/dcp_facilities_with_unmapped.py
+++ b/library/script/dcp_facilities_with_unmapped.py
@@ -1,0 +1,30 @@
+import pandas as pd
+from zipfile import ZipFile
+import requests
+
+from . import df_to_tempfile
+
+
+class Scriptor:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    @property
+    def version(self):
+        return self.config["dataset"]["version"]
+
+    def ingest(self) -> pd.DataFrame:
+        url = f"https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/facilities_{self.version}csv.zip"
+        r = requests.get(url, stream=True)
+        with open(f"dcp_facilities_with_unmapped{self.version}.zip", "wb") as fd:
+            for chunk in r.iter_content(chunk_size=128):
+                fd.write(chunk)
+        with ZipFile(f"dcp_facilities_with_unmapped{self.version}.zip", "r") as zip:
+            zip.extract(f"FacDB_{self.version}.csv")
+            df = pd.read_csv(f"FacDB_{self.version}.csv", encoding="ISO-8859-1")
+        return df
+
+    def runner(self) -> str:
+        df = self.ingest()
+        local_path = df_to_tempfile(df)
+        return local_path

--- a/library/templates/dcp_facilities_with_unmapped.yml
+++ b/library/templates/dcp_facilities_with_unmapped.yml
@@ -1,0 +1,36 @@
+dataset:
+  name: &name dcp_facilities_with_unmapped
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/facilities_{{ version }}csv.zip
+      subpath: "FacDB_20210811.csv"
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "PRECISION=NO"
+      - "OVERWRITE=YES"
+      - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## Facilities Database (FacDB) with unmapped records.
+      The Department of City Planning aggregates information about 30,000+ facilities and program sites that are owned, operated, funded, licensed, or certified by a City, State, or Federal agency in the City of New York into a central database called the City Planning Facilities Database (FacDB). These facilities generally help to shape quality of life in the city’s neighborhoods, and this dataset is the basis for a series of planning activities. This public data resource allows all New Yorkers to understand the breadth of government resources in their neighborhoods.
+      This dataset is now complemented with the Facilities Explorer, a new interactive web map that makes the data more accessible and allows users to quickly filter the data for their needs.
+      Note to Users: FacDB is only as good as the source data it aggregates, and the Department of City Planning cannot verify the accuracy of all records. Please read more about specific data and analysis limitations before using this data. Limitations include missing records, duplicate records, and the inclusion of administrative sites instead of service locations.
+      This is different from dcp_facilities in that it includes records that are never assigned a geography
+    url: "https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-selfac.page"
+    dependents: []

--- a/library/templates/dcp_facilities_with_unmapped.yml
+++ b/library/templates/dcp_facilities_with_unmapped.yml
@@ -3,9 +3,7 @@ dataset:
   version: "{{ version }}"
   acl: public-read
   source:
-    url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/facilities_{{ version }}csv.zip
-      subpath: "FacDB_20210811.csv"
+    script: *name
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"


### PR DESCRIPTION
`dcp_facilities_with_unmapped` pulls from the .csv on bytes instead of the shapefile. The .csv includes unmapped records. 

The data it pulls down for the Aug 11th 2021 release has 1309 more records than same version of dcp_facilities, which matches what I've seen before when debugging this issue.