### PR TITLE
update dot templates that require manual upload with better directions

### DIFF
--- a/library/templates/dot_bridgehouses.yml
+++ b/library/templates/dot_bridgehouses.yml
@@ -29,5 +29,18 @@ dataset:
     description: |
       ###  DOT Bridge Houses
       Recieved from DOT via email update
+      Source data has been sent in two ways:
+      * Individual zipped shapefile
+      * Part of geodatabase
+      If the data is sent via a geodatabse, there are some additional steps 
+      to load the data into data-library: 
+      1. Open the geodatabase in a GIS program (QGIS or ArcGIS)
+      2. Export individual shapefile following naming convention established in template.yml
+      * Make sure to save the file in the proper epsg (2263) which data-library converts to 4326
+      3. If not already compressed, compress shapefile, rename following naming convetnions in template 
+      and move into library/tmp/dot_xxxx.zip
+      4. Follow steps to update latest data in data-library
+
+
     url:
     dependents: []

--- a/library/templates/dot_ferryterminals.yml
+++ b/library/templates/dot_ferryterminals.yml
@@ -29,5 +29,16 @@ dataset:
     description: |
       ###  DOT Ferry Terminals
       Recieved from DOT via email update
+      Source data has been sent in two ways:
+      * Individual zipped shapefile
+      * Part of geodatabase
+      If the data is sent via a geodatabse, there are some additional steps 
+      to load the data into data-library: 
+      1. Open the geodatabase in a GIS program (QGIS or ArcGIS)
+      2. Export individual shapefile following naming convention established in template.yml
+       * Make sure to save the file in the proper epsg (2263) which data-library converts to 4326
+      3. If not already compressed, compress shapefile, rename following naming convetnions in template 
+      and move into library/tmp/dot_xxxx.zip
+      4. Follow steps to update latest data in data-library
     url:
     dependents: []

--- a/library/templates/dot_mannedfacilities.yml
+++ b/library/templates/dot_mannedfacilities.yml
@@ -29,5 +29,16 @@ dataset:
     description: |
       ###  DOT Manned Facilities
       Recieved from DOT via email update
+      Source data has been sent in two ways:
+      * Individual zipped shapefile
+      * Part of geodatabase
+      If the data is sent via a geodatabse, there are some additional steps 
+      to load the data into data-library: 
+      1. Open the geodatabase in a GIS program (QGIS or ArcGIS)
+      2. Export individual shapefile following naming convention established in template.yml
+       * Make sure to save the file in the proper epsg (2263) which data-library converts to 4326
+      3. If not already compressed, compress shapefile, rename following naming convetnions in template 
+      and move into library/tmp/dot_xxxx.zip
+      4. Follow steps to update latest data in data-library
     url:
     dependents: []

--- a/library/templates/dot_pedplazas.yml
+++ b/library/templates/dot_pedplazas.yml
@@ -29,5 +29,16 @@ dataset:
     description: |
       ###  DOT Pedestrial Plazas
       Recieved from DOT via email update
+            Source data has been sent in two ways:
+      * Individual zipped shapefile
+      * Part of geodatabase
+      If the data is sent via a geodatabse, there are some additional steps 
+      to load the data into data-library: 
+      1. Open the geodatabase in a GIS program (QGIS or ArcGIS)
+      2. Export individual shapefile following naming convention established in template.yml
+       * Make sure to save the file in the proper epsg (2263) which data-library converts to 4326
+      3. If not already compressed, compress shapefile, rename following naming convetnions in template 
+      and move into library/tmp/dot_xxxx.zip
+      4. Follow steps to update latest data in data-library
     url:
     dependents: []

--- a/library/templates/dot_publicparking.yml
+++ b/library/templates/dot_publicparking.yml
@@ -29,5 +29,16 @@ dataset:
     description: |
       ###  DOT Municipal Parking
       Recieved from DOT via email update
+            Source data has been sent in two ways:
+      * Individual zipped shapefile
+      * Part of geodatabase
+      If the data is sent via a geodatabse, there are some additional steps 
+      to load the data into data-library: 
+      1. Open the geodatabase in a GIS program (QGIS or ArcGIS)
+      2. Export individual shapefile following naming convention established in template.yml
+       * Make sure to save the file in the proper epsg (2263) which data-library converts to 4326
+      3. If not already compressed, compress shapefile, rename following naming convetnions in template 
+      and move into library/tmp/dot_xxxx.zip
+      4. Follow steps to update latest data in data-library
     url:
     dependents: []


### PR DESCRIPTION
This PR addresses Department of Transporatation (DOT) datasets we get via email (there are currently 5 - `dot_bridgehouese, dot_ferryterminals, dot_mannedfacilities, dot_pedplazas, dot_publicparking`) as written in issue #234. I wanted to add updated description information to highlight how to download the data via data-library if we receive the data as part of geodatabase instead of a stand alone shapefile. Simple changes to the description for all 5 templates