### PR TITLE
DOB NOW encoding

### DIFF
--- a/library/script/__init__.py
+++ b/library/script/__init__.py
@@ -3,7 +3,7 @@ import tempfile
 import pandas as pd
 
 
-def df_to_tempfile(df: pd.DataFrame, encode_utf_8=False) -> str:
+def df_to_tempfile(df: pd.DataFrame) -> str:
     f = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
     df.to_csv(f, index=False)
     return f.name

--- a/library/script/__init__.py
+++ b/library/script/__init__.py
@@ -7,5 +7,6 @@ def df_to_tempfile(df: pd.DataFrame, encode_utf_8=False) -> str:
     f = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
     if encode_utf_8:
         df.to_csv(f, encoding="utf-8", index=False)
-    df.to_csv(f, index=False)
+    else:
+        df.to_csv(f, index=False)
     return f.name

--- a/library/script/__init__.py
+++ b/library/script/__init__.py
@@ -5,8 +5,5 @@ import pandas as pd
 
 def df_to_tempfile(df: pd.DataFrame, encode_utf_8=False) -> str:
     f = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
-    if encode_utf_8:
-        df.to_csv(f, encoding="utf-8", index=False)
-    else:
-        df.to_csv(f, index=False)
+    df.to_csv(f, index=False)
     return f.name

--- a/library/script/__init__.py
+++ b/library/script/__init__.py
@@ -3,7 +3,9 @@ import tempfile
 import pandas as pd
 
 
-def df_to_tempfile(df: pd.DataFrame) -> str:
+def df_to_tempfile(df: pd.DataFrame, encode_utf_8=False) -> str:
     f = tempfile.NamedTemporaryFile(delete=False, suffix=".csv")
+    if encode_utf_8:
+        df.to_csv(f, encoding="utf-8", index=False)
     df.to_csv(f, index=False)
     return f.name

--- a/library/script/dob_now_applications.py
+++ b/library/script/dob_now_applications.py
@@ -1,19 +1,45 @@
+from multiprocessing import connection
 import pandas as pd
 
 from . import df_to_tempfile
+from dotenv import load_dotenv
+import boto3
+import os
 
+from io import StringIO
+
+# Load environmental variables
+load_dotenv()
 
 class Scriptor:
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
+    @property
+    def version(self):
+        return self.config["dataset"]["version"]
+
     def ingest(self) -> pd.DataFrame:
-        df = pd.read_csv("s3://edm-private/dob_now/DOB_Now_Job_Filing_Data_for_DCP_{{ version }}.csv", encoding="Windows-1252")
+        client = boto3.client(
+            "s3",
+            aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"],
+            aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"],
+            endpoint_url = os.environ["AWS_S3_ENDPOINT"]
+        )
+        obj = client.get_object(
+            Bucket="edm-private",
+            Key=f"dob_now/DOB_Now_Job_Filing_Data_for_DCP_{self.version}.csv",
+        )
+        #convert to a literal string of bytes with correct encoding
+        s = str(obj["Body"].read(), "Windows-1252")
+        # use StringIO to convert consumable format for pd.read_csv
+        data = StringIO(s)
+        df = pd.read_csv(data, encoding="Windows-1252")
         return df
 
     def runner(self) -> str:
         df = self.ingest()
-        local_path = df_to_tempfile(df, encode_utf_8=True)
+        local_path = df_to_tempfile(df)
         return local_path
 
 

--- a/library/script/dob_now_applications.py
+++ b/library/script/dob_now_applications.py
@@ -1,0 +1,19 @@
+import pandas as pd
+
+from . import df_to_tempfile
+
+
+class Scriptor:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def ingest(self) -> pd.DataFrame:
+        df = pd.read_csv("dob_now_applications.csv", encoding="Windows-1252")
+        return df
+
+    def runner(self) -> str:
+        df = self.ingest()
+        local_path = df_to_tempfile(df, encode_utf_8=True)
+        return local_path
+
+

--- a/library/script/dob_now_applications.py
+++ b/library/script/dob_now_applications.py
@@ -8,7 +8,7 @@ class Scriptor:
         self.__dict__.update(kwargs)
 
     def ingest(self) -> pd.DataFrame:
-        df = pd.read_csv("dob_now_applications.csv", encoding="Windows-1252")
+        df = pd.read_csv("s3://edm-private/dob_now/DOB_Now_Job_Filing_Data_for_DCP_{{ version }}.csv", encoding="Windows-1252")
         return df
 
     def runner(self) -> str:

--- a/library/templates/dob_now_applications.yml
+++ b/library/templates/dob_now_applications.yml
@@ -3,6 +3,7 @@ dataset:
   version: "{{ version }}"
   acl: public-read
   source:
+    script: *name
     url:
       path: s3://edm-private/dob_now/DOB_Now_Job_Filing_Data_for_DCP_{{ version }}.csv
       subpath: ""

--- a/library/templates/dob_now_applications.yml
+++ b/library/templates/dob_now_applications.yml
@@ -4,9 +4,6 @@ dataset:
   acl: public-read
   source:
     script: *name
-    url:
-      path: s3://edm-private/dob_now/DOB_Now_Job_Filing_Data_for_DCP_{{ version }}.csv
-      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -28,5 +25,7 @@ dataset:
   info:
     description: |
       DOB NOW job applications received from DOB via FTP
+      the python handles the encoding of the source file which is not standard utf-8.
+      Also the versioning of this file is based on the date received from DOB
     url: ""
     dependents: []


### PR DESCRIPTION
#215 

## Overview
This is enhancement to address the DOB NOW encoding being different the standard utf-8 which causes a downstream issue in the sql file created from data library process because sql server has a strict utf encoding requirement. 

## dob_now_applications.py
This purpose is actually quite simple. The main challenge before was uncertainty about how to ingest a file in edm-private which cannot be ingested with pandas with a url link. Going through data library carefully and we now understand that a separate pipeline using boto3 is needed to use execute the task. Some additional work is needed namely
```python
s = str(obj["Body"].read(), "Windows-1252")
data = StringIO(s)
```
because the boto3 `get_object` returns a `StreamingBody` wrapper object and `read` method makes it return the raw byte representation and using `StingIO` to allow `read_csv` to ingest the file successfully. 

## Question & Enhancement
I think one main question from me is that eventually this process will deposit a largely unprocessed file in edm recipe which will be public accessible from url. Does this defeat purpose of going through edm private?