### PR TITLE
update source geometry for `edc_capitalprojects` 

### DIFF
--- a/library/templates/edc_capitalprojects.yml
+++ b/library/templates/edc_capitalprojects.yml
@@ -10,7 +10,7 @@ dataset:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:2263
+      SRS: EPSG:3857
       type: MULTIPOLYGON
 
   destination:
@@ -28,6 +28,8 @@ dataset:
   info:
     description: |
       ### EDC Capital Projects
-      Received via email
+      Received via email - NOTE: source data geometry can change frequently, make sure to review output 
+      and the geometry (srs-epsg) matches a nyc lat/long. The shapefile can be brought into a GIS software
+      before ingestion to doublecheck correct source epsg.
     url:
     dependents: []


### PR DESCRIPTION
After building cpdb, we realized that the latest edc_capitalprojects data that we receive from edc via email has a different geometry than what was previously given to us. This PR addresses updating the source geometry (srs/epsg) so that a correct conversion can happen and adds a description to guide engineers on how to troubleshoot this issue.