### PR TITLE
Add script to DCAS IPIS to fix encoding

### DIFF
--- a/library/script/dcas_ipis.py
+++ b/library/script/dcas_ipis.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from . import df_to_tempfile
+from dotenv import load_dotenv
+
+# Load environmental variables
+load_dotenv()
+
+
+class Scriptor:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    @property
+    def version(self):
+        return self.config["dataset"]["version"]
+
+    @property
+    def filepath(self):
+        return self.config["dataset"]["source"]["filepath"]
+
+    def ingest(self) -> pd.DataFrame:
+        df = pd.read_csv(self.filepath, encoding="ISO-8859-1")
+        return df
+
+    def runner(self) -> str:
+        df = self.ingest()
+        local_path = df_to_tempfile(df)
+        return local_path

--- a/library/templates/dcas_ipis.yml
+++ b/library/templates/dcas_ipis.yml
@@ -3,9 +3,8 @@ dataset:
   version: "{{ version }}"
   acl: public-read
   source:
-    url:
-      path: library/tmp/dcas_ipis.csv
-      subpath: ""
+    script: *name
+    filepath: library/tmp/dcas_ipis.csv
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"


### PR DESCRIPTION
Modeled after Te's work on dob now applications dataset. Only new thing is a new `filepath` value nested under `source` in the associated yml. Similar to the typical `path` nested under `url`, the value points to the local file. The difference is that this `filepath` is used by the custom script whereas the typical `path` value is used in the main ingestion process. This was implemented so that the user can point to the correct file in the yml and doesn't have to go into the script for that.

Possible upgrade is figure out encoding programmatically instead of hard-coding it in.