### PR TITLE
fix typo in various dcp_ data library templates

### DIFF
--- a/library/templates/dcp_cb2010.yml
+++ b/library/templates/dcp_cb2010.yml
@@ -12,7 +12,7 @@ dataset:
       type: MULTIPOLYGON
     options:
       - "AUTODETECT_TYPE=NO"
-      - "STRING_EMPTY_AS_NULL=YES"
+      - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
     name: *name

--- a/library/templates/dcp_cb2010_wi.yml
+++ b/library/templates/dcp_cb2010_wi.yml
@@ -12,7 +12,7 @@ dataset:
       type: MULTIPOLYGON
     options:
       - "AUTODETECT_TYPE=NO"
-      - "STRING_EMPTY_AS_NULL=YES"
+      - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
     name: *name

--- a/library/templates/dcp_cb2020.yml
+++ b/library/templates/dcp_cb2020.yml
@@ -12,7 +12,7 @@ dataset:
       type: MULTIPOLYGON
     options:
       - "AUTODETECT_TYPE=NO"
-      - "STRING_EMPTY_AS_NULL=YES"
+      - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
     name: *name

--- a/library/templates/dcp_cb2020_wi.yml
+++ b/library/templates/dcp_cb2020_wi.yml
@@ -12,7 +12,7 @@ dataset:
       type: MULTIPOLYGON
     options:
       - "AUTODETECT_TYPE=NO"
-      - "STRING_EMPTY_AS_NULL=YES"
+      - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
     name: *name

--- a/library/templates/dcp_cdta2020.yml
+++ b/library/templates/dcp_cdta2020.yml
@@ -11,7 +11,7 @@ dataset:
       type: MULTIPOLYGON
     options:
       - AUTODETECT_TYPE=NO
-      - STRING_EMPTY_AS_NULL=YES
+      - EMPTY_STRING_AS_NULL=YES
   destination:
     name: *name
     geometry:

--- a/library/templates/dcp_congressionaldistricts.yml
+++ b/library/templates/dcp_congressionaldistricts.yml
@@ -15,7 +15,7 @@ dataset:
       type: MULTIPOLYGON
     options:
       - "AUTODETECT_TYPE=NO"
-      - "STRING_EMPTY_AS_NULL=YES"
+      - "EMPTY_STRING_AS_NULL=YES"
   destination:
     name: *name
     geometry:

--- a/library/templates/dcp_congressionaldistricts.yml
+++ b/library/templates/dcp_congressionaldistricts.yml
@@ -11,19 +11,19 @@ dataset:
       path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nycg_{{ version }}.zip
       subpath: nycg_{{ version }}/nycg.shp
     geometry:
-      SRS: EPSG:4326
+      SRS: EPSG:2263
       type: MULTIPOLYGON
     options:
-      - "AUTODETECT_TYPE=NO"
-      - "EMPTY_STRING_AS_NULL=YES"
+      - AUTODETECT_TYPE=NO
+      - EMPTY_STRING_AS_NULL=YES
   destination:
     name: *name
     geometry:
       SRS: EPSG:4326
       type: MULTIPOLYGON
     options:
-      - "OVERWRITE=YES"
-      - "PRECISION=NO"
+      - OVERWRITE=YES
+      - PRECISION=NO
     fields: []
     sql: null
   info:

--- a/library/templates/dcp_nta2010.yml
+++ b/library/templates/dcp_nta2010.yml
@@ -11,7 +11,7 @@ dataset:
       type: MULTIPOLYGON
     options:
       - AUTODETECT_TYPE=NO
-      - STRING_EMPTY_AS_NULL=YES
+      - EMPTY_STRING_AS_NULL=YES
   destination:
     name: *name
     geometry:

--- a/library/templates/dcp_nta2020.yml
+++ b/library/templates/dcp_nta2020.yml
@@ -11,7 +11,7 @@ dataset:
       type: MULTIPOLYGON
     options:
       - AUTODETECT_TYPE=NO
-      - STRING_EMPTY_AS_NULL=YES
+      - EMPTY_STRING_AS_NULL=YES
   destination:
     name: *name
     geometry:

--- a/library/templates/dcp_ntaboundaries.yml
+++ b/library/templates/dcp_ntaboundaries.yml
@@ -12,7 +12,7 @@ dataset:
       type: MULTIPOLYGON
     options:
       - "AUTODETECT_TYPE=NO"
-      - "STRING_EMPTY_AS_NULL=YES"
+      - "EMPTY_STRING_AS_NULL=YES"
 
   destination:
     name: *name


### PR DESCRIPTION
This PR addresses issue number #249 in data library but should also address a larger projection issue that was found in the QA/QC process for https://github.com/NYCPlanning/db-pluto/issues/315. In db-pluto, @AmandaDoyle found that there were records where census tracts were being populated but the census block column was not which didn't make any sense. @Oysters1874 and I took a look into what the issue might be and she found that the spatial join in db-pluto between census block and tract worked if you specified the projection of the census block files in the join which led us to think that there was an issue with the projection coming from data library. 

We discovered that there was a misspelling in the census block files (dcp_cb2020, dcp_cb2020_wi, etc...) with a value in the template "EMPTY_STRING_AS_NULL=YES" (correct way of spelling the var) was actually spelled as "STRING_EMPTY_AS_NULL=YES" in the census block templates. This was never caught in data library because it wouldn't throw an error but it did impact the projection - I don't totally understand as to why but with the correction in spelling the projections seem to be working now. After further exploration, I found 9 total templates with this misspelling error. 

You can test this PR by running the files through data-library locally but I also tested it by updating a version of dcp_cb2010_wi in digital ocean https://cloud.digitalocean.com/spaces/edm-recipes?i=266877&path=datasets%2Fdcp_cb2010_wi%2F22a%2F. This link should bring you to the 22a version but with the most recent change in the template

Templates that need to be checked:

- [x] dcp_cb2010_wi
- [x] dcp_cb2010
- [x] dcp_cb2020_wi
- [x] dcp_cb2020
- [x] dcp_cdta2020
- [x] dcp_congressionaldistricts
- [x] dcp_nta2010
- [x] dcp_nta2020
- [x] dcp_ntaboundaries