### PR TITLE
258 fix pluto corrections template

### DIFF
--- a/library/templates/pluto_corrections.yml
+++ b/library/templates/pluto_corrections.yml
@@ -13,13 +13,13 @@ dataset:
       - Y_POSSIBLE_NAMES=latitude,Latitude,Lat,lat,y
     geometry:
       SRS: null
-      type: None
+      type: NONE
 
   destination:
     name: *name
     geometry:
       SRS: null
-      type: None
+      type: NONE
     options:
       - "OVERWRITE=YES"
       - "PRECISION=NO"

--- a/library/templates/pluto_corrections.yml
+++ b/library/templates/pluto_corrections.yml
@@ -9,8 +9,8 @@ dataset:
     options:
       - AUTODETECT_TYPE=NO
       - EMPTY_STRING_AS_NULL=YES
-      - X_POSSIBLE_NAMES=longitude,Longitude
-      - Y_POSSIBLE_NAMES=latitude,Latitude
+      - X_POSSIBLE_NAMES=longitude,Longitude,Lon,lon,x
+      - Y_POSSIBLE_NAMES=latitude,Latitude,Lat,lat,y
     geometry:
       SRS: null
       type: None


### PR DESCRIPTION
After testing, the [PR](https://github.com/NYCPlanning/db-data-library/pull/257) to #256. I found that the `pluto_corrections` template did not download properly using the library archive commands, this PR addresses the minor fix and standardizes the `options` parameters `X_POSSIBLE_NAMES` and `Y_POSSIBLE_NAMES` to match the `dcla_culturalinstitutions` template