### PR TITLE
Add Version Parameter to Upload Single Dataset Workflow 

### DIFF
--- a/.github/workflows/single-runner.yml
+++ b/.github/workflows/single-runner.yml
@@ -4,15 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       dataset:
-        description: "Name of the dataset"
+        description: "Name of the dataset (required)"
         required: true
         default: dcp_mappluto
       latest:
-        description: "Tag this version as latest"
+        description: "Tag this version as latest (optional)"
         required: false
         default: "true"
       version:
-        description: "Optional. The version of the dataset (i.e. 22v2, 21C) if needed"
+        description: "The version of the dataset (i.e. 22v2, 21C) if needed (optional)"
         required: false
 
 

--- a/.github/workflows/single-runner.yml
+++ b/.github/workflows/single-runner.yml
@@ -11,6 +11,10 @@ on:
         description: 'Tag this version as latest'
         required: false
         default: 'true'
+      version:
+        description: "Version of the dataset (i.e. 22v2, 20221121)"
+        required: true
+        
 
 
 jobs:

--- a/.github/workflows/single-runner.yml
+++ b/.github/workflows/single-runner.yml
@@ -13,7 +13,7 @@ on:
         default: "true"
       version:
         description: "Version of the dataset (i.e. 22v2, 20221121)"
-        required: true
+        required: false
 
 
 

--- a/.github/workflows/single-runner.yml
+++ b/.github/workflows/single-runner.yml
@@ -4,17 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       dataset:
-        description: 'Name of the dataset'
+        description: "Name of the dataset"
         required: true
         default: dcp_mappluto
       latest:
-        description: 'Tag this version as latest'
+        description: "Tag this version as latest"
         required: false
-        default: 'true'
+        default: "true"
       version:
         description: "Version of the dataset (i.e. 22v2, 20221121)"
         required: true
-        
+
 
 
 jobs:
@@ -32,6 +32,7 @@ jobs:
         with:
           name: ${{ github.event.inputs.dataset }}
           latest: ${{ github.event.inputs.latest }}
+          version: ${{ github.event.inputs.version }}
           s3: true
           compress: true
           output_format: pgdump shapefile csv

--- a/.github/workflows/single-runner.yml
+++ b/.github/workflows/single-runner.yml
@@ -12,7 +12,7 @@ on:
         required: false
         default: "true"
       version:
-        description: "Version of the dataset (i.e. 22v2, 20221121)"
+        description: "Optional. The version of the dataset (i.e. 22v2, 21C) if needed"
         required: false
 
 


### PR DESCRIPTION
This PR addresses #267. One reviewer required ⭐ .

Generally, we have been updating `edm-recipe` datasets via the command line with `library archive` but a github action was set up to facilitate these uploads that wasn't widely used. When trying to upload the default `dcp_mappluto` dataset earlier, an `assertionerror` was thrown because of the way PLUTO datasets are versioned via data library (`22v2 or 22v3` as supposed to other datasets which are versioned by the date i.e. `20221121`. This PR adds a parameter to the workflow in which the user has to specify a version to upload to data library. 

To test, I ran the workflow off this branch which can be viewed here: https://github.com/NYCPlanning/db-data-library/actions/runs/3517220403
To confirm this action successfully ran, I checked the edm-recipes space on data library to make sure dcp_mappluto was updated.

Note that a green check, doesn't necessarily mean a successful run as seen in this run of the workflow: https://github.com/NYCPlanning/db-data-library/actions/runs/3516153549

