### PR TITLE
Update  URL path for `dcp_boroboundaries` and `dcp_boroboundaries_wi`

### DIFF
--- a/library/templates/dcp_boroboundaries.yml
+++ b/library/templates/dcp_boroboundaries.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nybb_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nybb_{{ version }}.zip
       subpath: nybb_{{ version }}/nybb.shp
     options:
       - "AUTODETECT_TYPE=NO"

--- a/library/templates/dcp_boroboundaries_wi.yml
+++ b/library/templates/dcp_boroboundaries_wi.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nybbwi_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nybbwi_{{ version }}.zip
       subpath: nybbwi_{{ version }}/nybbwi.shp
     options:
       - "AUTODETECT_TYPE=NO"
@@ -29,4 +29,8 @@ dataset:
       ### ESRI Shapefile
       The borough boundaries of New York City including portions of the borough under water.
     url: https://www1.nyc.gov/site/planning/data-maps/open-data/districts-download-metadata.page
-    dependents: []
+    dependents: 
+      - db-cpdb
+      - db-knownprojects
+      - db-developments
+      


### PR DESCRIPTION
One reviewer required. Addresses issue #276  and two tasks in#272. Mistakenly named the feature branch 275 instead of 276.

Update the url path to reflect change in the Bytes of the Big Apple server.

Test by running the dataset locally.