### PR TITLE
Update Url for `dcp_cb2020_wi` & `dcp_cb2020` 

### DIFF
--- a/library/templates/dcp_cb2020.yml
+++ b/library/templates/dcp_cb2020.yml
@@ -5,7 +5,7 @@ dataset:
 
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nycb2020_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycb2020_{{ version }}.zip
       subpath: nycb2020_{{ version }}/nycb2020.shp
     geometry:
       SRS: EPSG:2263
@@ -28,4 +28,5 @@ dataset:
     description: |
       ### The Census Blocks for the 2020 US Census (Clipped to shoreline).
     url: https://www1.nyc.gov/site/planning/data-maps/open-data/districts-download-metadata.page
-    dependents: []
+    dependents: 
+      - db-developments

--- a/library/templates/dcp_cb2020_wi.yml
+++ b/library/templates/dcp_cb2020_wi.yml
@@ -5,7 +5,7 @@ dataset:
 
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nycb2020wi_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycb2020wi_{{ version }}.zip
       subpath: nycb2020wi_{{ version }}/nycb2020wi.shp
     geometry:
       SRS: EPSG:2263
@@ -27,5 +27,6 @@ dataset:
   info:
     description: |
       ### The Census Blocks for the 2020 US Census (**Water included**). 
-    url:
-    dependents: []
+    url: 
+    dependents:
+      - db-pluto


### PR DESCRIPTION
One reviewer required. Addresses issue #280  and two tasks in #272.

Update the url path to reflect change in the Bytes of the Big Apple server.

Test by running the dataset locally.