### PR TITLE
Update url path `dcp_cdta2020`

### DIFF
--- a/library/templates/dcp_cdta2020.yml
+++ b/library/templates/dcp_cdta2020.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nycdta2020_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycdta2020_22c.zip
       subpath: nycdta2020_{{ version }}/nycdta2020.shp
     geometry:
       SRS: EPSG:2263

--- a/library/templates/dcp_cdta2020.yml
+++ b/library/templates/dcp_cdta2020.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycdta2020_22c.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycdta2020_{{ version }}.zip
       subpath: nycdta2020_{{ version }}/nycdta2020.shp
     geometry:
       SRS: EPSG:2263


### PR DESCRIPTION
One reviewer required. Addresses issue #284 and one task in #272

Update the url path to reflect change in the Bytes of the Big Apple server.

Test by running the dataset locally.