### PR TITLE
update url `dcp_congresionaldistricts`

### DIFF
--- a/library/templates/dcp_congressionaldistricts.yml
+++ b/library/templates/dcp_congressionaldistricts.yml
@@ -5,10 +5,7 @@ dataset:
 
   source:
     url:
-      # path: nycg_21b/nycg.shp
-      # subpath: ""
-      # For some reason the zip file for 21b is not working right, so we are doing a local archive this time
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nycg_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycg_{{ version }}.zip
       subpath: nycg_{{ version }}/nycg.shp
     geometry:
       SRS: EPSG:2263

--- a/library/templates/dcp_congressionaldistricts.yml
+++ b/library/templates/dcp_congressionaldistricts.yml
@@ -27,4 +27,5 @@ dataset:
     description: |
       ### U.S. Congressional Districts (Clipped to Shoreline)
     url: https://www1.nyc.gov/site/planning/data-maps/open-data/districts-download-metadata.page
-    dependents: []
+    dependents:
+      - db-cpdb


### PR DESCRIPTION
One reviewer required. Addresses issue #289 and one task from #272.

Update the url path to reflect change in the Bytes of the Big Apple server.

Test by running the dataset locally.

Note - dcp_congressionaldistricts is the clipped version, will create a new template for _wi