### PR TITLE
create new template for `dcp_congressionaldistricts_wi`

### DIFF
--- a/library/templates/dcp_congressionaldistricts_wi.yml
+++ b/library/templates/dcp_congressionaldistricts_wi.yml
@@ -1,0 +1,30 @@
+dataset:
+  name: &name dcp_congressionaldistricts_wi
+  version: "{{ version }}"
+  acl: public-read
+
+  source:
+    url:
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycgwi_{{ version }}.zip
+      subpath: nycgwi_{{ version }}/nycgwi.shp
+    geometry:
+      SRS: EPSG:2263
+      type: MULTIPOLYGON
+    options:
+      - AUTODETECT_TYPE=NO
+      - EMPTY_STRING_AS_NULL=YES
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: MULTIPOLYGON
+    options:
+      - OVERWRITE=YES
+      - PRECISION=NO
+    fields: []
+    sql: null
+  info:
+    description: |
+      ### U.S. Congressional Districts (Water Included)
+    url: https://www1.nyc.gov/site/planning/data-maps/open-data/districts-download-metadata.page
+    dependents:


### PR DESCRIPTION
This PR addresses issue #291.

Unlike our other admin boundary data, `dcp_congressionaldistricts` doesn't have an accompanying `_wi` template to download the water included congressional districts boundary file for bytes of the big apple. Add the `dcp_congressionaldistricts_wi` template to fix pattern break for these files. 

I think one question here is whether or not we should change the dataloading steps in cpdb to get the new `_wi` data