### PR TITLE
update url path for `dcp_stateassemblydistricts` and `dcp_stateassemblydistricts_wi`

### DIFF
--- a/library/templates/dcp_stateassemblydistricts.yml
+++ b/library/templates/dcp_stateassemblydistricts.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyad_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyad_{{ version }}.zip
       subpath: nyad_{{ version }}/nyad.shp
     geometry:
       SRS: EPSG:2263

--- a/library/templates/dcp_stateassemblydistricts_wi.yml
+++ b/library/templates/dcp_stateassemblydistricts_wi.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyadwi_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyadwi_{{ version }}.zip
       subpath: nyadwi_{{ version }}/nyadwi.shp
     geometry:
       SRS: EPSG:2263


### PR DESCRIPTION
#293 see spike issue #272 

two in one since they are both state assembly districts.

Should be no downstream impacts.