### PR TITLE
update url `dcp_nta2010`, `dcp_nta2020` & `dcp_ntaboundaries`

### DIFF
--- a/library/templates/dcp_nta2010.yml
+++ b/library/templates/dcp_nta2010.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nynta2010_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nynta2010_{{ version }}.zip
       subpath: nynta2010_{{ version }}/nynta2010.shp
     geometry:
       SRS: EPSG:2263

--- a/library/templates/dcp_nta2020.yml
+++ b/library/templates/dcp_nta2020.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nynta2020_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nynta2020_{{ version }}.zip
       subpath: nynta2020_{{ version }}/nynta2020.shp
     geometry:
       SRS: EPSG:2263

--- a/library/templates/dcp_ntaboundaries.yml
+++ b/library/templates/dcp_ntaboundaries.yml
@@ -5,8 +5,8 @@ dataset:
 
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nynta_{{ version }}.zip
-      subpath: nynta_{{ version }}/nynta.shp
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nynta2020_{{ version }}.zip
+      subpath: nynta2020_{{ version }}/nynta2020.shp
     geometry:
       SRS: EPSG:2263
       type: MULTIPOLYGON


### PR DESCRIPTION
#299 see #272 for spike issue

update urls for all nta templates.

after some investigation it was determined that the `dcp_ntaboundaries` is going to be the same as `dcp_nta2020`. 