### PR TITLE
update url for  `dcp_ct2010_wi` and  `dcp ct2010`

### DIFF
--- a/library/templates/dcp_ct2010.yml
+++ b/library/templates/dcp_ct2010.yml
@@ -5,7 +5,7 @@ dataset:
 
   source:
     url: 
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyct2010_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyct2010_{{ version }}.zip
       subpath: nyct2010_{{ version }}/nyct2010.shp
     geometry:
       SRS: EPSG:2263

--- a/library/templates/dcp_ct2010_wi.yml
+++ b/library/templates/dcp_ct2010_wi.yml
@@ -5,7 +5,7 @@ dataset:
 
   source:
     url: 
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyct2010wi_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyct2010wi_{{ version }}.zip
       subpath: nyct2010wi_{{ version }}/nyct2010wi.shp
     geometry:
       SRS: EPSG:2263


### PR DESCRIPTION
One reviewer required. Addresses issue #305  and two tasks in #272 .

Update the url path to reflect change in the Bytes of the Big Apple server.

Test by running the dataset locally.