### PR TITLE
update URL `dcp_ct2020_wi` and `dcp_ct2020` 

### DIFF
--- a/library/templates/dcp_ct2020.yml
+++ b/library/templates/dcp_ct2020.yml
@@ -5,7 +5,7 @@ dataset:
 
   source:
     url: 
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyct2020_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyct2020_{{ version }}.zip
       subpath: nyct2020_{{ version }}/nyct2020.shp
     geometry:
       SRS: EPSG:2263

--- a/library/templates/dcp_ct2020_wi.yml
+++ b/library/templates/dcp_ct2020_wi.yml
@@ -5,7 +5,7 @@ dataset:
 
   source:
     url: 
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyct2020wi_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyct2020wi_{{ version }}.zip
       subpath: nyct2020wi_{{ version }}/nyct2020wi.shp
     geometry:
       SRS: EPSG:2263


### PR DESCRIPTION
One reviewer required. Addresses issue #308 and two tasks in #272. feature branch should be 308-update-ct2020 but accidentally had a typo.

Update the url path to reflect change in the Bytes of the Big Apple server.

Test by running the dataset locally.