### PR TITLE
update url `dcp_zoningtaxlots`

### DIFF
--- a/library/templates/dcp_zoningtaxlots.yml
+++ b/library/templates/dcp_zoningtaxlots.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyczoningtaxlotdb_{{ version }}.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyczoningtaxlotdb_{{ version }}.zip
       subpath: "NY_ZoningTaxLotDB{{ version }}.csv"
     options:
       - "AUTODETECT_TYPE=NO"


### PR DESCRIPTION
Addresses issue #321 and one task in #272. One reviewer required ⭐ 

Update the url path to reflect change in the Bytes of the Big Apple server.

Test by running the dataset locally.