### PR TITLE
update dcp_mappluto_wi template

### DIFF
--- a/library/templates/dcp_mappluto_wi.yml
+++ b/library/templates/dcp_mappluto_wi.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyc_mappluto_{{ version }}_unclipped_shp.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyc_mappluto_{{version}}_unclipped_shp.zip
       subpath: MapPLUTO_UNCLIPPED.shp
     options:
       - "AUTODETECT_TYPE=NO"

--- a/library/templates/dcp_mappluto_wi.yml
+++ b/library/templates/dcp_mappluto_wi.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyc_mappluto_{{version}}_unclipped_shp.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyc_mappluto_{{ version }}_unclipped_shp.zip
       subpath: MapPLUTO_UNCLIPPED.shp
     options:
       - "AUTODETECT_TYPE=NO"


### PR DESCRIPTION
one reviewer #328 

KPDB use `dcp_mappluto_wi` and currently the latest is 22v2 on DO. 

I know we were holding off updating mappluto related templates before. After considering the consequences of making updates, I believe we will need to be careful with updating `dcp_mappluto` or `dcp_mappluto_clipped` but for any datasets already using `dcp_mappluto_wi` already it should be no impact for us to update the url. But please let me know if I didn't cover all my bases when thinking this through. 

Once this is merged in and updated. I think we are ready to build KPDB. 