### PR TITLE
Add `dcp_pad` to Bytes Quartely Update Workflow and reorder datasets alphabetically 

### DIFF
--- a/.github/workflows/quaterly-updates.yml
+++ b/.github/workflows/quaterly-updates.yml
@@ -41,9 +41,10 @@ jobs:
           - dcp_councildistricts
           - dcp_councildistricts_wi
           - dcp_firecompanies
-          - dcp_policeprecincts
           - dcp_healthareas
           - dcp_healthcenters
+          - dcp_pad
+          - dcp_policeprecincts
           - dcp_school_districts
     steps:
       - uses: actions/checkout@v2.3.4


### PR DESCRIPTION
This issue addresses #330. One reviewer req ⭐ 

`dcp_pad` is a critical dataset for our db-gru-qaqc checks and hasn't been updated regularly. It is released on a quarterly cycle and therefore should be updated along with the other quarterly updates. 