### PR TITLE
bpl_libraries handle empty position field

### DIFF
--- a/library/script/bpl_libraries.py
+++ b/library/script/bpl_libraries.py
@@ -18,6 +18,7 @@ class Scriptor:
         for i in content["locations"]:
             data.append(i["data"])
         df = pd.DataFrame.from_dict(data, orient="columns")
+        df.loc[df["position"] == "", "position"] = ","
         df['latitude'] = df.position.apply(lambda x: x.split(',')[0].strip())
         df['longitude'] = df.position.apply(lambda x: x.split(',')[1].strip())
         return df


### PR DESCRIPTION
one reviewer is fine 🌞 

#336 

An issue where the position field where we got the lat long for the record is breaking because blank `position` would not be able to handled by the extraction logics.

I will admit it is a pretty hacky way to handle the error but I don't believe it would break anything else. Tested locally on my machine and output seems in line with what we had in the past. The lat long for the empty position record would both be empty strings. 