### PR TITLE
Update `foodbankny_foodbanks` to pass a version and update directions

### DIFF
--- a/library/templates/foodbankny_foodbanks.yml
+++ b/library/templates/foodbankny_foodbanks.yml
@@ -34,6 +34,6 @@ dataset:
       and click "Export Data" and export as a csv 
       4. Rename the file (still as a csv) to match Food_Bank_For_NYC_Open_Members_as_of_DATE(dmmyy)
       5. place it at the library/tmp folder 
-      4. then run library archive --name foodbankny_foodbanks with the -version flag set to the DATE in the file path
+      6. then run library archive --name foodbankny_foodbanks with the -version flag set to the DATE in the file path
     url: "http://www.foodbanknyc.org/get-help/"
     dependents: []

--- a/library/templates/foodbankny_foodbanks.yml
+++ b/library/templates/foodbankny_foodbanks.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: "Food_Bank_For_NYC_Open_Members_as_of_4622.csv"
+      path: "library/tmp/Food_Bank_For_NYC_Open_Members_as_of_{{ version }}.csv"
       subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
@@ -29,8 +29,11 @@ dataset:
       > Map results of soup kitchen, food pantry, senior center, or SNAP enrollment site locactions
       ## Update Instructions
       1. head to http://www.foodbanknyc.org/get-help/
-      2. navigate to the map and download it as kml
-      3. place it at a local directory, edit foodbankny_foodbanks.yml to reflect the local path
-      4. then run library archive --name foodbankny_foodbanks ...
+      2. navigate to the map and make a copy of the map
+      3. After making a copy, click on the three dots next to the target layer 
+      and click "Export Data" and export as a csv 
+      4. Rename the file (still as a csv) to match Food_Bank_For_NYC_Open_Members_as_of_DATE(dmmyy)
+      5. place it at the library/tmp folder 
+      4. then run library archive --name foodbankny_foodbanks with the -version flag set to the DATE in the file path
     url: "http://www.foodbanknyc.org/get-help/"
     dependents: []


### PR DESCRIPTION
Addresses issue #338. One reviewer required ⭐ 

Had some issues downloading and converting the kml/kmz files to a csv directly from the GoogleMap [here](https://www.google.com/maps/d/u/0/viewer?mid=1uVjjVxXfLFU4R6V7qjXXRoxCy-IwfMSP&ll=40.706960814039434%2C-73.97175925000002&z=10). The original directions stated that they should be downloaded and converted via a specific kml to csv convertor found on the internet but I found that making a copy of the map and then just exporting the layer as a csv worked best. I also implemented the version parameter which is standard on most of our templates. 

I ran locally and archive worked as expected.
 
Let me know if you have any questions or concerns