### PR TITLE
Update URL for `usdot_ports`

### DIFF
--- a/library/templates/usdot_ports.yml
+++ b/library/templates/usdot_ports.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://opendata.arcgis.com/datasets/d824e107008942558881bc598b05c60b_0.geojson
+      path: https://services7.arcgis.com/n1YM8pTrFmm7L4hs/ArcGIS/rest/services/ndc/FeatureServer/2/query?outFields=*&where=1%3D1&f=geojson
       subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"


### PR DESCRIPTION
One reviewer required. Addresses issue #341.

After some more sleuthing, I found a dataset that matches the older version of the `usdot_ports` dataset we need for facilities database. To test, you can run this locally (withour pushing to s3) and view the file as a csv. This dataset contains records "_The location of a manmade water-land interface structure often used for access to boats or ships.

The Docks dataset was compiled on June 08, 2020 from the United States Army Corp of Engineers (USACE) and is part of the U.S. Department of Transportation (USDOT)/Bureau of Transportation Statistics (BTS) National Transportation Atlas Database (NTAD). The dataset contains physical information on commercial facilities at U.S. Coastal, Great Lakes and Inland Ports. The data consists of location description, street address, city, county name, congressional district FIPS code, type of construction, cargo-handling equipment, water depth alongside the facility, facility type (dock, fleeting area, lock and/or dam) berthing space, latitude, longitude, current operators and owner's information, list of commodities handled at facility, road/railway connections, equipment available at facility, storage facilities, cranes, transit sheds, grain elevators, marine repair plants, fleeting areas, and docking, and facility start/stop date._"