### PR TITLE
doe lcgms manual upload

### DIFF
--- a/library/templates/doe_lcgms.yml
+++ b/library/templates/doe_lcgms.yml
@@ -3,7 +3,9 @@ dataset:
   version: "{{ version }}"
   acl: public-read
   source:
-    script: *name
+    url:
+      path: library/tmp/LCGMS_SchoolData_{{ version }}.csv
+      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -25,6 +27,10 @@ dataset:
   info:
     description: |
       ### LCGMS - New York City district and charter school information
+      ### file format
+      the downloadable is xls workbook which Data Library does not work with
+      needs to manually open it in Excel then save as a csv in library/tmp folder 
+      before uploading
       #### The spreadsheet includes:
       - school names
       - addresses

--- a/library/templates/doe_lcgms.yml
+++ b/library/templates/doe_lcgms.yml
@@ -27,10 +27,12 @@ dataset:
   info:
     description: |
       ### LCGMS - New York City district and charter school information
-      ### file format
+      ### file format & naming
       the downloadable is xls workbook which Data Library does not work with
       needs to manually open it in Excel then save as a csv in library/tmp folder 
       before uploading
+      the default naming of the file includes hour and minute timestamp which needs
+      to be removed to keep better consistency with our other datasets
       #### The spreadsheet includes:
       - school names
       - addresses

--- a/library/templates/doe_lcgms.yml
+++ b/library/templates/doe_lcgms.yml
@@ -47,5 +47,5 @@ dataset:
       ### How to run
       Follow directions in associated python script
       If that doesn't work, convert the downloaded file to a .csv manually and update process to ingest from the csv
-    url: "https://infohub.nyced.org/in-our-schools/operations/lcgms"
+    url: "https://www.nycenet.edu/PublicApps/LCGMS.aspx"
     dependents: []


### PR DESCRIPTION
#340 one reviewer required

Changing the template back to using the manually download to because `aspx` protocol this dataset uses makes the programatic way to pull the dataset unsustainable. See `library/script/doe_lcgms.py` for the script to pull dataset and instructions from before.

the new template at `library/templates/doe_lcgms.yml` includes some new instructions about the downloadable workbook upload process and eccentricity about its naming and file format. 