### PR TITLE
Add updated description to `foodbankny_foodbanks` to properly format date 

### DIFF
--- a/library/templates/foodbankny_foodbanks.yml
+++ b/library/templates/foodbankny_foodbanks.yml
@@ -32,7 +32,7 @@ dataset:
       2. navigate to the map and make a copy of the map
       3. After making a copy, click on the three dots next to the target layer 
       and click "Export Data" and export as a csv 
-      4. Rename the file (still as a csv) to match Food_Bank_For_NYC_Open_Members_as_of_DATE(dmmyy)
+      4. Rename the file (still as a csv) to match Food_Bank_For_NYC_Open_Members_as_of_DATE(YYYYMMDD). You will need to convert the existing date format MMDDYY to YYYYMMDD so that the version matches existing date format standard in data library.
       5. place it at the library/tmp folder 
       6. then run library archive --name foodbankny_foodbanks with the -version flag set to the DATE in the file path
     url: "http://www.foodbanknyc.org/get-help/"


### PR DESCRIPTION
One reviewer required. Addresses issue #344.

Add to existing description to properly rename the file with correct date format i.e YYYYDDMM