### PR TITLE
Use script to add encoding for `doe_lcgms`

### DIFF
--- a/library/script/doe_lcgms.py
+++ b/library/script/doe_lcgms.py
@@ -8,7 +8,12 @@ from . import df_to_tempfile
 
 class Scriptor:
     """
-    NOTE: May 6, 2022 The request body for downloading the spreadsheet has not been stable from one year to the next.
+    NOTE: 
+    Dec 23, 2022 the ingest() has since being deprecated because the request endpoints and params are not stable.
+    New ingest_csv() takes the static csv and created according to the documentation in the yml template is used 
+    for data library.
+
+    May 6, 2022 The request body for downloading the spreadsheet has not been stable from one year to the next.
     View https://www.nycenet.edu/PublicApps/LCGMS.aspx in developer mode (⌘+⌥+C on mac) (with Chrome in this case).
     Then click " Downloadable School Data in Excel Format".
     Then navigate to the network tab and click on the "LCGMS.aspx" listed in the box titled "Names".
@@ -25,6 +30,10 @@ class Scriptor:
 
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
+
+    @property
+    def version(self):
+        return self.config["dataset"]["version"]
 
     def ingest(self) -> pd.DataFrame:
         headers = {
@@ -49,8 +58,12 @@ class Scriptor:
         df.columns = df.iloc[0].str.replace("\t", " ")  # First row as column names
         df = df[1:]
         return df
+    
+    def ingest_csv(self):
+        df = pd.read_csv(f"library/tmp/LCGMS_SchoolData_{self.version}.csv", encoding="utf-8")
+        return df
 
     def runner(self) -> str:
-        df = self.ingest()
+        df = self.ingest_csv()
         local_path = df_to_tempfile(df)
         return local_path

--- a/library/templates/doe_lcgms.yml
+++ b/library/templates/doe_lcgms.yml
@@ -3,9 +3,7 @@ dataset:
   version: "{{ version }}"
   acl: public-read
   source:
-    url:
-      path: library/tmp/LCGMS_SchoolData_{{ version }}.csv
-      subpath: ""
+    script: *name
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
@@ -29,10 +27,11 @@ dataset:
       ### LCGMS - New York City district and charter school information
       ### file format & naming
       the downloadable is xls workbook which Data Library does not work with
-      needs to manually open it in Excel then save as a csv in library/tmp folder 
-      before uploading
+      needs to manually open it in Excel then save as a csv utf-8 encoding in library/tmp folder 
+      before uploading.
       the default naming of the file includes hour and minute timestamp which needs
-      to be removed to keep better consistency with our other datasets
+      to be removed to keep better consistency with our other datasets. The version for the csv should 
+      contain the year, month and day like other dataset e.g. LCGMS_SchoolData_20221215.csv
       #### The spreadsheet includes:
       - school names
       - addresses


### PR DESCRIPTION
Third time the charm hopefully for #340 

After @mbh329 facdb ingestion would [throw an encoding error](https://github.com/NYCPlanning/db-facilities/actions/runs/3760589448/jobs/6391467528) on the `doe_lcgms` which took me back to the drawing board and reactivate the script process to ingest the dataset. 

The new workflow requires a two-step process which is documented in the `library/templates/doe_lcgms.yml`. First, manually download the `.xls` file then convert it into a `utf-8` encoding csv. Then after it is moved to the `tmp` folder, the `library/script/doe_lcgms.py` script can be run to finish the upload. 

## ingest_csv()
I opted to write another separate function for the new process of ingesting the csv because I don't feel entirely comfortable yet to delete all the works from before to work with the `aspx` endpoint. I did add additional documentation on this new work and it is fairly simple in its functionality. 