### PR TITLE
Update `dcp_mappluto` url to new bytes server

### DIFF
--- a/library/templates/dcp_mappluto.yml
+++ b/library/templates/dcp_mappluto.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyc_mappluto_{{ version }}_unclipped_shp.zip
+      path: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyc_mappluto_{{ version }}_unclipped_shp.zip
       subpath: MapPLUTO_UNCLIPPED.shp
     options:
       - "AUTODETECT_TYPE=NO"


### PR DESCRIPTION
Addresses issue #372. Related to issue #316. 

Notes:
* `dcp_mappluto` and `dcp_mappluto_wi` are historically and currently the same thing. A change was never implemented to address the newer naming convention that is in place for other source datasets in which the `_wi` suffix relates to files that include water vs the absence of `_wi` which are clipped to the shoreline. As of now, we will continue to keep them the same until more research is done to understand the impact of this. 
* This datasets url change when the Bytes server changed urls - we need to update this in order to ingest 22v3 mappluto which is ingested via the new url