### PR TITLE
Add template for `cbbr_submissions`

### DIFF
--- a/library/templates/cbbr_submissions.yml
+++ b/library/templates/cbbr_submissions.yml
@@ -1,0 +1,31 @@
+dataset:
+  name: &name cbbr_submissions
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: library/tmp/cbbr_submissions.csv
+      subpath: ""
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: null
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ###  
+    url:
+    dependents: []

--- a/library/templates/cbbr_submissions.yml
+++ b/library/templates/cbbr_submissions.yml
@@ -40,7 +40,8 @@ dataset:
       1. Select the cell (or column) where the VLOOKUP formula is
       2. Right click and select "Copy"
       3. Select the cell or column with the VLOOKUP and select "Paste Special..."
-      4. In the Paste Special Dialog popup, Clcik on "Values" option
+      4. In the Paste Special Dialog popup, select the "Values" option (the data should now 
+      persist without the need for the VLOOKUP)
       5. Delete the "Keys" sheet and save as a cbbr_submissions.csv (the csv file is needed as it's the 
       acceptable tabular format for data-library)
       6. Add the cbbr_submissions.csv to library/tmp/cbbr_submissions.csv path

--- a/library/templates/cbbr_submissions.yml
+++ b/library/templates/cbbr_submissions.yml
@@ -26,6 +26,10 @@ dataset:
 
   info:
     description: |
-      ###  
-    url:
+      ###  The cbbr_submissions (Community Board Budget Requests) data consists of budget 
+      requests submitted through NYC's various community boards. Each record consists of 
+      an indiviudal budget request and the responsible agencies response to each formal 
+      budget request. This data is compiled by DCP Strategic Planning and given to DCP Data
+      Engineering team as an xlsx file which is manually uploaded and ingested via data-library.
+    url: https://www.nyc.gov/site/cau/community-boards/community-boards.page 
     dependents: []

--- a/library/templates/cbbr_submissions.yml
+++ b/library/templates/cbbr_submissions.yml
@@ -33,7 +33,14 @@ dataset:
       Engineering team as an xlsx file which is manually uploaded and ingested via data-library.
       In the latest iteration of the .xlsx file we recieved from DCP Strategic Planning,  
       a vlookup function was used to get key value pairs in certain columns which created invalid data
-      when saving the file as a csv. To bypass this, I saved the values in the columns as they appeared 
-      (negating any need for a lookup).
+      when saving the file as a csv. 
+      To bypass this, the DE member can (in the original source data file):
+      1. Select the cell (or column) where the VLOOKUP formula is
+      2. Right click and select "Copy"
+      3. Select the cell or column with the VLOOKUP and select "Paste Special..."
+      4. In the Paste Special Dialog popup, Clcik on "Values" option
+      5. Delete the "Keys" sheet and save as a .csv (the csv file is needed as it's the 
+      acceptable tabular format for data-library)
+      6. Test that the file is uploaded correctly and columns populate with valid data 
     url: https://www.nyc.gov/site/cau/community-boards/community-boards.page 
     dependents: []

--- a/library/templates/cbbr_submissions.yml
+++ b/library/templates/cbbr_submissions.yml
@@ -31,6 +31,8 @@ dataset:
       an indiviudal budget request and the responsible agencies response to each formal 
       budget request. This data is compiled by DCP Strategic Planning and given to DCP Data
       Engineering team as an xlsx file which is manually uploaded and ingested via data-library.
+
+      Note:
       In the latest iteration of the .xlsx file we recieved from DCP Strategic Planning,  
       a vlookup function was used to get key value pairs in certain columns which created invalid data
       when saving the file as a csv. 
@@ -39,8 +41,9 @@ dataset:
       2. Right click and select "Copy"
       3. Select the cell or column with the VLOOKUP and select "Paste Special..."
       4. In the Paste Special Dialog popup, Clcik on "Values" option
-      5. Delete the "Keys" sheet and save as a .csv (the csv file is needed as it's the 
+      5. Delete the "Keys" sheet and save as a cbbr_submissions.csv (the csv file is needed as it's the 
       acceptable tabular format for data-library)
-      6. Test that the file is uploaded correctly and columns populate with valid data 
+      6. Add the cbbr_submissions.csv to library/tmp/cbbr_submissions.csv path
+      7. Test that the file is uploaded correctly and columns populate with valid data 
     url: https://www.nyc.gov/site/cau/community-boards/community-boards.page 
     dependents: []

--- a/library/templates/cbbr_submissions.yml
+++ b/library/templates/cbbr_submissions.yml
@@ -31,5 +31,9 @@ dataset:
       an indiviudal budget request and the responsible agencies response to each formal 
       budget request. This data is compiled by DCP Strategic Planning and given to DCP Data
       Engineering team as an xlsx file which is manually uploaded and ingested via data-library.
+      In the latest iteration of the .xlsx file we recieved from DCP Strategic Planning,  
+      a vlookup function was used to get key value pairs in certain columns which created invalid data
+      when saving the file as a csv. To bypass this, I saved the values in the columns as they appeared 
+      (negating any need for a lookup).
     url: https://www.nyc.gov/site/cau/community-boards/community-boards.page 
     dependents: []


### PR DESCRIPTION

Notes:
* Addresses issue #374 and connected to [issue 27 in db-ccbr](https://github.com/NYCPlanning/db-cbbr/issues/27).
* Create a yaml template to manually ingest cbbr_submissions data based of excel spreadsheet we received from strategic planning
* To test, I ingested the data locally and viewed the csv files so that the data persisted as expected. In the original xlsx, a `vlookup` function was used to get key value pairs in certain columns which created invalid data when saving the file into a csv. To bypass this, I saved the values in the columns as they appeared (negating any need for a lookup).
* Outputs are available in [DO](https://cloud.digitalocean.com/spaces/edm-recipes?i=266877&path=datasets%2Fcbbr_submissions%2F20230215%2F)