### PR TITLE
Change encoding of `dob_now_application.py` script to utf-8

### DIFF
--- a/library/script/dob_now_applications.py
+++ b/library/script/dob_now_applications.py
@@ -31,10 +31,10 @@ class Scriptor:
             Key=f"dob_now/dob_now_job_applications/DOB_Now_Job_Filing_Data_for_DCP_{self.version}.csv",
         )
         #convert to a literal string of bytes with correct encoding
-        s = str(obj["Body"].read(), "Windows-1252")
+        s = str(obj["Body"].read(), "utf-8")
         # use StringIO to convert consumable format for pd.read_csv
         data = StringIO(s)
-        df = pd.read_csv(data, encoding="Windows-1252")
+        df = pd.read_csv(data, encoding="utf-8")
         return df
 
     def runner(self) -> str:

--- a/library/templates/dob_now_applications.yml
+++ b/library/templates/dob_now_applications.yml
@@ -24,9 +24,10 @@ dataset:
 
   info:
     description: |
-      DOB NOW job applications received from DOB via FTP which is hosted by Matt and manually moved to sharepoint
-      the python handles the encoding of the source file which is not standard utf-8 and also ingesting
-      from the edm-private s3 bucket.
+      DOB NOW job applications received from DOB via the DOB FTP which can be accessed via CyberDuck on DCP 
+      Windows machines (see internal documentation for credentials). The encoding standard of 
+      the file should be double checked before and after uploading to Digital Ocean as it 
+      has changed between versions (from "Windows-1252" to "utf-8", etc).
 
       There is an extensive writeup in a github issue about DOB NOW custome job filing data
       https://github.com/NYCPlanning/db-developments/issues/386#issue-864138806


### PR DESCRIPTION
Addresses issue #376. 

Notes:

- After running a devdb build, there were errors in the log pointing to "odd" column name changes in which special characters were being inserted into the column schema. I checked the `dob_now_application.csv` encoding and found that the new .CSV DOB(downloaded via their FTP)  gave us is in utf-8 as supposed to older versions of the file which were encoded in Windows-1252. See dev-db build log [here](https://github.com/NYCPlanning/db-developments/actions/runs/4196116376/jobs/7276639078#step:9:69)
- Adding a note to the template to view the csv encoding type before upload 
- feature branch issue is misnamed, should be `376-dob-now...` MY BAD