### PR TITLE
ensure errors cause failures

### DIFF
--- a/.github/workflows/single-runner.yml
+++ b/.github/workflows/single-runner.yml
@@ -15,8 +15,6 @@ on:
         description: "The version of the dataset (i.e. 22v2, 21C) if needed (optional)"
         required: false
 
-
-
 jobs:
   dataloading:
     runs-on: ubuntu-20.04
@@ -27,7 +25,7 @@ jobs:
       AWS_S3_BUCKET: edm-recipes
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: NYCPlanning/action-library-archive@v1.1
+      - uses: NYCPlanning/action-library-archive@v1.2
         name: Archive ${{ github.event.inputs.dataset }}
         with:
           name: ${{ github.event.inputs.dataset }}

--- a/library.sh
+++ b/library.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
+set -e
+
 function init {
     UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 10 | head -n 1)
     docker build . -t library:$UUID
-    echo "$UUID" > .config
+    echo "$UUID" >.config
 }
 
 function library_execute {
@@ -10,13 +12,12 @@ function library_execute {
         echo "run ./library.sh init first to initialize"
     else
         UUID=$(cat .config)
-        docker run --rm --tty --env-file .env\
-            -u $(id -u ${USER}):$(id -g ${USER})\
+        docker run --rm --tty --env-file .env -u $(id -u ${USER}):$(id -g ${USER}) \
             -v $(pwd):/library library:$UUID library $@
     fi
 }
 
 case $1 in
-    init) init ;;
-    *) library_execute $@;;
+init) init ;;
+*) library_execute $@ ;;
 esac

--- a/library/templates/dcp_mih.yml
+++ b/library/templates/dcp_mih.yml
@@ -4,7 +4,7 @@ dataset:
   acl: public-read
   source:
     url:
-      path: https://nyc3.digitaloceanspaces.com/edm-publishing/datasets/mandatory_inclusionary_housing/staging/gis_mandatory_inclusionary_housing.zip
+      path: https://nyc3.digitaloceanspaces.com/edm-publishing/datasets/dcp_inclusionary_housing/staging/dcp_inclusionary_housing.zip
       subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"


### PR DESCRIPTION
## motivations
- while looking into a ZTLB issue, noticed that the data loading the ZTLB repo is [failing silently](https://github.com/NYCPlanning/db-zoningtaxlots/actions/runs/4346355817/jobs/7592307150#step:4:159)
- in that example and many others, [our published archive GHA](https://github.com/NYCPlanning/action-library-archive) is being used. that action uses the docker image defined and published by this repo

## todo
- test changes here
- ensure [our published archive GHA](https://github.com/NYCPlanning/action-library-archive) has these changes