### PR TITLE
Default input missing on push triggering workflow

### DIFF
--- a/.github/workflows/update_image.yml
+++ b/.github/workflows/update_image.yml
@@ -12,7 +12,6 @@ on:
           - ubuntu-staging
           - ubuntu-latest
   push:
-    branches: main
 
 jobs:
   update_image:
@@ -20,7 +19,7 @@ jobs:
     env:
       AW_DOCKER_USERNAME: ${{ secrets.AW_Docker_Username }}
       AW_DOCKER_PASSWORD: ${{ secrets.AW_Docker_Password }}
-      image_tag: nycplanning/library:${{ github.event.inputs.image_tag}}
+      image_tag: nycplanning/library:${{ github.event.inputs.image_tag || 'ubuntu-staging' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/update_image.yml
+++ b/.github/workflows/update_image.yml
@@ -7,11 +7,11 @@ on:
         type: choice
         description: Name of release
         required: true
-        default: ubuntu-latest
         options:
           - ubuntu-staging
           - ubuntu-latest
   push:
+    branches: main
 
 jobs:
   update_image:
@@ -19,7 +19,7 @@ jobs:
     env:
       AW_DOCKER_USERNAME: ${{ secrets.AW_Docker_Username }}
       AW_DOCKER_PASSWORD: ${{ secrets.AW_Docker_Password }}
-      image_tag: nycplanning/library:${{ github.event.inputs.image_tag || 'ubuntu-staging' }}
+      image_tag: nycplanning/library:${{ github.event.inputs.image_tag || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
And one other. See this failure

https://github.com/NYCPlanning/db-data-library/actions/runs/4734381721/jobs/8403220541

Workflows triggered by 'push' have no access to 'default' value for the workflow dispatch input, so need to specify another way

Fixed in below action, on push in this branch

https://github.com/NYCPlanning/db-data-library/actions/runs/4734427865

Verification that other option can be specified when using workflow dispatch (had swapped whether latest/staging was default here)

https://github.com/NYCPlanning/db-data-library/actions/runs/4734465371