### PR TITLE
Single runner version bug

### DIFF
--- a/.github/workflows/single-runner.yml
+++ b/.github/workflows/single-runner.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Archive ${{ github.event.inputs.dataset }}
         env:
           latest: ${{ github.event.inputs.latest == 'true' && '--latest' || ' ' }}
-          version: ${{ github.event.inputs.version || ' ' }}
+          version: ${{ github.event.inputs.version && format('--version {0}', github.event.inputs.version) || ' ' }}
         run: |
           poetry run library archive --name ${{ github.event.inputs.dataset }} -o pgdump --s3 --compress $latest $version
           poetry run library archive --name ${{ github.event.inputs.dataset }} -o shapefile --s3 --compress $latest $version


### PR DESCRIPTION
When I updated the single runner yaml file [here](https://github.com/NYCPlanning/db-data-library/pull/385/files#diff-b214fd847afeabec30ea7b7a218332895fd7fcbd23322b1fa8e3936b7dfddb4f), messed up the logic around version being specified

See failed run here:

https://github.com/NYCPlanning/db-data-library/actions/runs/4787598456/jobs/8513040987

`--version` was not being added, but instead the version was just added as an extraneous argument

Rerunning now

https://github.com/NYCPlanning/db-data-library/actions/runs/4787740610