### PR TITLE
Fvk fix docker image publication

### DIFF
--- a/.github/workflows/update_image.yml
+++ b/.github/workflows/update_image.yml
@@ -27,11 +27,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: nycplanning/library:${{ github.event.inputs.image_tag || 'ubuntu-latest' }}
+          images: nycplanning/library
       - name: print intermediate outputs
         run: |
-          echo ${{ steps.meta.outputs.tags }}
-          echo ${{ steps.meta.outputs.labels }}
+          echo "${{ steps.meta.outputs.tags }}"
+          echo "${{ steps.meta.outputs.labels }}"
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:

--- a/.github/workflows/update_image.yml
+++ b/.github/workflows/update_image.yml
@@ -23,21 +23,12 @@ jobs:
         with:
           username: ${{ secrets.AW_Docker_Username }}
           password: ${{ secrets.AW_Docker_Password }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: nycplanning/library
-      - name: print intermediate outputs
-        run: |
-          echo "${{ steps.meta.outputs.tags }}"
-          echo "${{ steps.meta.outputs.labels }}"
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: nycplanning/library:${{ github.event.inputs.image_tag || 'ubuntu-latest' }}
           labels: ${{ steps.meta.outputs.labels }}
 
   update_docs:

--- a/.github/workflows/update_image.yml
+++ b/.github/workflows/update_image.yml
@@ -29,7 +29,6 @@ jobs:
           context: .
           push: true
           tags: nycplanning/library:${{ github.event.inputs.image_tag || 'ubuntu-latest' }}
-          labels: ${{ steps.meta.outputs.labels }}
 
   update_docs:
     needs: update_image

--- a/.github/workflows/update_image.yml
+++ b/.github/workflows/update_image.yml
@@ -28,6 +28,10 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: nycplanning/library:${{ github.event.inputs.image_tag || 'ubuntu-latest' }}
+      - name: print intermediate outputs
+        run: |
+          echo ${{ steps.meta.outputs.tags }}
+          echo ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:

--- a/.github/workflows/update_image.yml
+++ b/.github/workflows/update_image.yml
@@ -16,24 +16,18 @@ on:
 jobs:
   update_image:
     runs-on: ubuntu-22.04
-    env:
-      AW_DOCKER_USERNAME: ${{ secrets.AW_Docker_Username }}
-      AW_DOCKER_PASSWORD: ${{ secrets.AW_Docker_Password }}
-      image_tag: nycplanning/library:${{ github.event.inputs.image_tag || 'ubuntu-latest' }}
-
     steps:
       - uses: actions/checkout@v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
-          username: $AW_DOCKER_USERNAME
-          password: $AW_DOCKER_PASSWORD
+          username: ${{ secrets.AW_Docker_Username }}
+          password: ${{ secrets.AW_Docker_Password }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: $image_tag
+          images: nycplanning/library:${{ github.event.inputs.image_tag || 'ubuntu-latest' }}
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:


### PR DESCRIPTION
## PR doesn't quite show changes because of my accidental push to main. See links in this description

Before, we were using [this action](https://github.com/docker-practice/actions-setup-docker) to setup docker and run via commands. This was having some sort of internal failure while installing things via `apt-get`.

With these changes, we're no longer setting up docker, but logging, buildling and pushing via [docker's official published actions](https://github.com/docker). Specifically, [login-action](https://github.com/docker/login-action) and [build-push-action](https://github.com/docker/build-push-action)

See changes in original push to main [here](https://github.com/NYCPlanning/db-data-library/commit/347654eeeaeaf8292e4071c40d864baa8d79ed3c)

See failing workflow runs prior to changes [here](https://github.com/NYCPlanning/db-data-library/actions/runs/4799942161/jobs/8540236685). 