### PR TITLE
Cache Config.compute property

### DIFF
--- a/library/config.py
+++ b/library/config.py
@@ -8,7 +8,7 @@ from jinja2 import Template
 
 from .utils import format_url, get_execution_details
 from .validator import Validator
-
+from functools import cached_property
 
 # Custom dumper created for list indentation
 class Dumper(yaml.Dumper):
@@ -76,7 +76,7 @@ class Config:
         """
         return datetime.today().strftime("%Y%m%d")
 
-    @property
+    @cached_property
     def compute(self) -> dict:
         """based on given yml file, compute the configuration"""
 


### PR DESCRIPTION
The `compute` property in `Config` calls `Scriptor.runner()` if the source for a data set is a python script. In `Ingestor.translator`, there are potentially 3 total calls to this property, one via `compute_parsed` [here](https://github.com/NYCPlanning/db-data-library/blob/main/library/ingest.py#L55) and then two others via `Config.compute_json` and `compute_yml` [here](https://github.com/NYCPlanning/db-data-library/blob/main/library/ingest.py#L85) (each of these three properties reference the `compute` property). 

In cases where `Scriptor.runner()` is making web calls (such as [doitt_building_footprints](https://github.com/NYCPlanning/db-data-library/actions/runs/4724962876/jobs/8382817005)), this is causing 3 calls to download the same file, each time creating a new temporary download file.

doitt_buildingfootprints [still failing](https://github.com/NYCPlanning/db-data-library/actions/runs/4834262774) for unrelated reasons, but at least it's failing quicker now that it's only downloading once!