### PR TITLE
Fix sql statement in GDAL VectorTranslate

### DIFF
--- a/library/ingest.py
+++ b/library/ingest.py
@@ -77,8 +77,6 @@ class Ingestor:
             dataset_name = destination["name"]
             sql = destination.get("sql", None)
             sql = None if not sql else sql.replace("@filename", layerName)
-            print(sql)
-            print("test")
             
             # Create output folder and output config
             if folder_path and output_suffix:

--- a/library/ingest.py
+++ b/library/ingest.py
@@ -77,7 +77,9 @@ class Ingestor:
             dataset_name = destination["name"]
             sql = destination.get("sql", None)
             sql = None if not sql else sql.replace("@filename", layerName)
-
+            print(sql)
+            print("test")
+            
             # Create output folder and output config
             if folder_path and output_suffix:
                 os.makedirs(folder_path, exist_ok=True)
@@ -125,7 +127,7 @@ class Ingestor:
                     makeValid=True,
                     # optional settings
                     SQLStatement=sql,
-                    SQLDialect="PostgreSQL",
+                    SQLDialect="SQLite",
                     callback=update_progress,
                 )
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,3 +23,5 @@ TEST_DATASET_OUTPUT_DIRECTORY = (
 )
 TEST_DATASET_OUTPUT_PATH = f"{TEST_DATASET_OUTPUT_DIRECTORY}/{TEST_DATASET_NAME}"
 TEST_DATASET_OUTPUT_PATH_S3 = f"datasets/{TEST_DATASET_NAME}/{TEST_DATASET_VERSION}"
+
+get_config_file = lambda filename: f"{test_root_path}/data/{filename}.yml"

--- a/tests/data/bpl_libraries_sql.yml
+++ b/tests/data/bpl_libraries_sql.yml
@@ -1,0 +1,38 @@
+dataset:
+  name: &name bpl_libraries
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    script: *name
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+      - "X_POSSIBLE_NAMES=longitude"
+      - "Y_POSSIBLE_NAMES=latitude"
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+
+  destination:
+    name: *name
+    geometry:
+      SRS: EPSG:4326
+      type: POINT
+    options:
+      - "OVERWRITE=YES"
+      - "GEOMETRY=AS_WKT"
+    fields: []
+    sql: |
+      SELECT title, count(*) as count
+      FROM @filename
+      WHERE title IS NOT NULL
+      GROUP BY title
+
+  info:
+    description: |
+      BPL libraries is a dataset that we webscrape and store
+      in a csv format, checkout the Brooklyn Public Library
+      website(https://www.bklynlibrary.org/locations) for
+      more information
+    url: "https://www.bklynlibrary.org/locations"
+    dependents: []

--- a/tests/data/url.yml
+++ b/tests/data/url.yml
@@ -1,64 +1,32 @@
 dataset:
-  name: &name dcp_mappluto
+  name: &name usdot_airports
   version: "{{ version }}"
   acl: public-read
-  # Source definition
   source:
-    url:
-      # The url or local path for this data source
-      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyc_mappluto_{{ version }}_unclipped_shp.zip
-      # For zipped files, specify subpath to help gdal locate data
-      subpath: nyc_mappluto_{{ version }}_unclipped/nyc_mappluto_{{ version }}.shp
-    options: #srcOpenOptions
+    script: *name
+    path: https://adip.faa.gov/publishedAirports/all-airport-data.xlsx
+    options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:2263
-      type: MULTIPOLYGON
+      SRS: null
+      type: NONE
 
-  # Destination definition
   destination:
     name: *name
     geometry:
-      SRS: EPSG:4326
-      type: MULTIPOLYGON
-    options: #layerCreationOptions
+      SRS: null
+      type: NONE
+    options:
       - "OVERWRITE=YES"
+      - "PRECISION=NO"
     fields: []
+    sql: SELECT * FROM @filename
 
-    # If there's a SQL statement we would like to perform
-    # @filename syntax can be used to indicate that the content
-    # is in the pointed filename.
-    sql: |
-      SELECT * FROM @filename LIMIT 5
-
-  # The info field is a free-formed field to include any other additional info
   info:
-    # some simple description here
     description: |
-      dcp_mappluto is the shoreline clipped, grabbed from bytes
-      more information here, if ">" is used then it means that
-      newlines are not preserved. if "|" is used then it means
-      that newline will be preserved
-    # A url that doesn't lead directly to the data file but a
-    # human readable website url would be useful here
-    url: https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page
-    dependents:
-      - pluto_corrections
-      - pluto_input_numbldgs
-      - dcp_edesignation
-      - dcp_colp
-      - lpc_historic_districts
-      - lpc_landmarks
-      - dcp_cdboundaries
-      - dcp_censustracts
-      - dcp_censusblocks
-      - dcp_school_districts
-      - dcp_councildistricts
-      - doitt_zipcodeboundaries
-      - dcp_firecompanies
-      - dcp_policeprecincts
-      - dcp_healthareas
-      - dcp_healthcenters
-      - dsny_frequencies
-      - dpr_greenthumb
+      ## Airports
+      the published 5010 Excel sheet from includes all airports and heliports registered with FAA(Federal Avfiation Administration) which is under USDOT last update in Apr 22 2022
+      a script process is used to ingest the excel spreadsheet and get the appropriate tab as a csv to complete the process uploading to our s3 space
+    url: https://adip.faa.gov/agis/public/#/airportSearch/advanced
+    dependents: []

--- a/tests/data/url.yml
+++ b/tests/data/url.yml
@@ -1,33 +1,64 @@
 dataset:
-  name: &name usdot_ports
+  name: &name dcp_mappluto
   version: "{{ version }}"
   acl: public-read
+  # Source definition
   source:
     url:
-      path: https://services7.arcgis.com/n1YM8pTrFmm7L4hs/ArcGIS/rest/services/ndc/FeatureServer/2/query?outFields=*&where=1%3D1&f=geojson
-      subpath: ""
-    options:
+      # The url or local path for this data source
+      path: https://www1.nyc.gov/assets/planning/download/zip/data-maps/open-data/nyc_mappluto_{{ version }}_unclipped_shp.zip
+      # For zipped files, specify subpath to help gdal locate data
+      subpath: nyc_mappluto_{{ version }}_unclipped/nyc_mappluto_{{ version }}.shp
+    options: #srcOpenOptions
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: EPSG:4326
-      type: POINT
+      SRS: EPSG:2263
+      type: MULTIPOLYGON
 
+  # Destination definition
   destination:
     name: *name
     geometry:
       SRS: EPSG:4326
-      type: POINT
-    options:
+      type: MULTIPOLYGON
+    options: #layerCreationOptions
       - "OVERWRITE=YES"
-      - "PRECISION=NO"
-      - "GEOMETRY=AS_WKT"
     fields: []
-    sql: null
 
+    # If there's a SQL statement we would like to perform
+    # @filename syntax can be used to indicate that the content
+    # is in the pointed filename.
+    sql: |
+      SELECT * FROM @filename LIMIT 5
+
+  # The info field is a free-formed field to include any other additional info
   info:
+    # some simple description here
     description: |
-      ## Ports
-      The Ports dataset is part of the U.S. Department of Transportation (USDOT)/Bureau of Transportation Statistics's (BTS's) National Transportation Atlas Database (NTAD). Contains physical information on commercial facilities at U.S. Coastal, Great Lakes and Inland Ports. The data consists of location description, street address, city, county name, congressional district FIPS code, type of construction, cargo-handling equipment, water depth alongside the facility, facility type ( dock, fleeting area, lock and/or dam) berthing space, latitude, longitude, current operators and owner's information, list of commodities handled at facility, road/railway connections, equipment available at facility, storage facilities, cranes, transit sheds, grain elevators, marine repair plants, fleeting areas, and docking, and facility start/stop date.
-    url: https://hub.arcgis.com/datasets/usdot::ports
-    dependents: []
+      dcp_mappluto is the shoreline clipped, grabbed from bytes
+      more information here, if ">" is used then it means that
+      newlines are not preserved. if "|" is used then it means
+      that newline will be preserved
+    # A url that doesn't lead directly to the data file but a
+    # human readable website url would be useful here
+    url: https://www1.nyc.gov/site/planning/data-maps/open-data/dwn-pluto-mappluto.page
+    dependents:
+      - pluto_corrections
+      - pluto_input_numbldgs
+      - dcp_edesignation
+      - dcp_colp
+      - lpc_historic_districts
+      - lpc_landmarks
+      - dcp_cdboundaries
+      - dcp_censustracts
+      - dcp_censusblocks
+      - dcp_school_districts
+      - dcp_councildistricts
+      - doitt_zipcodeboundaries
+      - dcp_firecompanies
+      - dcp_policeprecincts
+      - dcp_healthareas
+      - dcp_healthcenters
+      - dsny_frequencies
+      - dpr_greenthumb

--- a/tests/data/url.yml
+++ b/tests/data/url.yml
@@ -1,32 +1,33 @@
 dataset:
-  name: &name usdot_airports
+  name: &name usdot_ports
   version: "{{ version }}"
   acl: public-read
   source:
-    script: *name
-    path: https://adip.faa.gov/publishedAirports/all-airport-data.xlsx
+    url:
+      path: https://services7.arcgis.com/n1YM8pTrFmm7L4hs/ArcGIS/rest/services/ndc/FeatureServer/2/query?outFields=*&where=1%3D1&f=geojson
+      subpath: ""
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"
     geometry:
-      SRS: null
-      type: NONE
+      SRS: EPSG:4326
+      type: POINT
 
   destination:
     name: *name
     geometry:
-      SRS: null
-      type: NONE
+      SRS: EPSG:4326
+      type: POINT
     options:
       - "OVERWRITE=YES"
       - "PRECISION=NO"
+      - "GEOMETRY=AS_WKT"
     fields: []
-    sql: SELECT * FROM @filename
+    sql: null
 
   info:
     description: |
-      ## Airports
-      the published 5010 Excel sheet from includes all airports and heliports registered with FAA(Federal Avfiation Administration) which is under USDOT last update in Apr 22 2022
-      a script process is used to ingest the excel spreadsheet and get the appropriate tab as a csv to complete the process uploading to our s3 space
-    url: https://adip.faa.gov/agis/public/#/airportSearch/advanced
+      ## Ports
+      The Ports dataset is part of the U.S. Department of Transportation (USDOT)/Bureau of Transportation Statistics's (BTS's) National Transportation Atlas Database (NTAD). Contains physical information on commercial facilities at U.S. Coastal, Great Lakes and Inland Ports. The data consists of location description, street address, city, county name, congressional district FIPS code, type of construction, cargo-handling equipment, water depth alongside the facility, facility type ( dock, fleeting area, lock and/or dam) berthing space, latitude, longitude, current operators and owner's information, list of commodities handled at facility, road/railway connections, equipment available at facility, storage facilities, cranes, transit sheds, grain elevators, marine repair plants, fleeting areas, and docking, and facility start/stop date.
+    url: https://hub.arcgis.com/datasets/usdot::ports
     dependents: []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,25 +1,24 @@
 from pathlib import Path
-
 from library.config import Config
 
-from . import template_path
+from . import template_path, get_config_file
 
 
 def test_config_parsed_rendered_template():
-    c = Config(f"{Path(__file__).parent}/data/url.yml")
+    c = Config(get_config_file("url"))
     rendered = c.parsed_rendered_template(version="20v7")
     assert rendered["dataset"]["version"] == "20v7"
 
 
 def test_config_source_type():
-    c = Config(f"{Path(__file__).parent}/data/socrata.yml")
+    c = Config(get_config_file("socrata"))
     assert c.source_type == "socrata"
-    c = Config(f"{Path(__file__).parent}/data/url.yml")
+    c = Config(get_config_file("url"))
     assert c.source_type == "url"
 
 
 def test_config_version_socrata():
-    c = Config(f"{Path(__file__).parent}/data/socrata.yml")
+    c = Config(get_config_file("socrata"))
     uid = c.parsed_unrendered_template["dataset"]["source"]["socrata"]["uid"]
     version = c.version_socrata(uid)
     assert len(version) == 8  # format: YYYYMMDD
@@ -28,7 +27,7 @@ def test_config_version_socrata():
 
 
 def test_config_version_today():
-    c = Config(f"{Path(__file__).parent}/data/socrata.yml")
+    c = Config(get_config_file("socrata"))
     version = c.version_today
     assert len(version) == 8  # format: YYYYMMDD
     assert int(version[-2:]) <= 31  # check date
@@ -36,13 +35,13 @@ def test_config_version_today():
 
 
 def test_config_compute():
-    config = Config(f"{Path(__file__).parent}/data/socrata.yml").compute
+    config = Config(get_config_file("socrata")).compute
     assert type(config["dataset"]["source"]["url"]) == dict
 
 
 def test_config_compute_parsed():
     dataset, source, destination, info = Config(
-        f"{Path(__file__).parent}/data/socrata.yml"
+        get_config_file("socrata")
     ).compute_parsed
     assert dataset["source"] == source
     assert dataset["info"] == info

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -5,6 +5,7 @@ from library.ingest import Ingestor
 from . import (
     pg,
     recipe_engine,
+    get_config_file,
     TEST_DATASET_NAME,
     TEST_DATASET_VERSION,
     TEST_DATASET_CONFIG_FILE,
@@ -62,3 +63,7 @@ def test_ingest_version_overwrite():
     assert os.path.isfile(
         f".library/datasets/{TEST_DATASET_NAME}/{version_overwrite}/{TEST_DATASET_NAME}.csv"
     )
+
+def test_ingest_with_sql():
+    ingestor = Ingestor()
+    ingestor.csv(get_config_file("url"))

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -66,4 +66,4 @@ def test_ingest_version_overwrite():
 
 def test_ingest_with_sql():
     ingestor = Ingestor()
-    ingestor.csv(get_config_file("url"))
+    ingestor.csv(get_config_file("bpl_libraries_sql"))


### PR DESCRIPTION
Closes #398 and adds test for a sql group by statement in vector translate

Copying text from issue:

> So a fairly innocuous looking change was made here
>
> https://github.com/NYCPlanning/db-data-library/commit/3803454a7edf724c7d48440297885e615193c7d1#diff-5a31bf7a3838bfb58f602bce217962045a1c1dde0f950dc28c397c7a6909ef5eR128
>
> As far as I can tell, we only have one dataset that actually uses this functionality
>
> https://github.com/NYCPlanning/db-pluto/actions/workflows/input_numbldgs.yml
>
> And has been failing since this change. Testing locally, reverting to sqlite work. Looking at [gdal docs](https://gdal.org/user/sql_sqlite_dialect.html) the `SQLDialect` option in `VectorTranslate` might only support the native "OGR SQL" and sqlite. So it might just be falling back to ogr which might not support group by clauses? Running with ogr sql has same error as when specifying postgresql.
>
> This is a tough one to google.
>
> @damonmcc I think it'd be best to just revert that line to sqlite