### PR TITLE
Add census data

### DIFF
--- a/library/script/bpl_libraries.py
+++ b/library/script/bpl_libraries.py
@@ -9,8 +9,7 @@ class Scriptor(ScriptorInterface):
         self.__dict__.update(kwargs)
 
     def ingest(self) -> pd.DataFrame:
-        url = "https://www.bklynlibrary.org/locations/json"
-        content = get_json_content(url)
+        content = get_json_content(self.path)
         data = []
         for i in content["locations"]:
             data.append(i["data"])

--- a/library/script/dcp_censusdata.py
+++ b/library/script/dcp_censusdata.py
@@ -1,7 +1,4 @@
-import json
-
 import pandas as pd
-import requests
 
 from . import df_to_tempfile
 from .scriptor import ScriptorInterface

--- a/library/script/dcp_censusdata.py
+++ b/library/script/dcp_censusdata.py
@@ -1,0 +1,29 @@
+import json
+
+import pandas as pd
+import requests
+
+from . import df_to_tempfile
+from .scriptor import ScriptorInterface
+
+
+class Scriptor(ScriptorInterface):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        
+    @property
+    def get_columns(self):
+        if self.version == "2010":
+            return "A:AP"
+        if self.version == "2020":
+            return "A:H,AQ:BX"
+        raise ValueError("2010 and 2020 are only supported versions for decennial census data")
+
+    def ingest(self) -> pd.DataFrame:
+        df = pd.read_excel(self.path, sheet_name="2010, 2020, and Change", usecols=self.get_columns, skiprows=3)
+        return df
+
+    def runner(self) -> str:
+        df = self.ingest()
+        local_path = df_to_tempfile(df)
+        return local_path

--- a/library/script/dcp_censusdata_blocks.py
+++ b/library/script/dcp_censusdata_blocks.py
@@ -1,7 +1,4 @@
-import json
-
 import pandas as pd
-import requests
 
 from . import df_to_tempfile
 from .scriptor import ScriptorInterface

--- a/library/script/dcp_censusdata_blocks.py
+++ b/library/script/dcp_censusdata_blocks.py
@@ -1,0 +1,29 @@
+import json
+
+import pandas as pd
+import requests
+
+from . import df_to_tempfile
+from .scriptor import ScriptorInterface
+
+
+class Scriptor(ScriptorInterface):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+        
+    @property
+    def get_columns(self):
+        if self.version == "2010":
+            return "A:AO"
+        if self.version == "2020":
+            return "A:E,AP:BY"
+        raise ValueError("2010 and 2020 are only supported versions for decennial census data")
+
+    def ingest(self) -> pd.DataFrame:
+        df = pd.read_excel(self.path, sheet_name="2010 and 2020 data in 2020 geog", usecols=self.get_columns, skiprows=1)
+        return df
+
+    def runner(self) -> str:
+        df = self.ingest()
+        local_path = df_to_tempfile(df)
+        return local_path

--- a/library/script/dcp_colp.py
+++ b/library/script/dcp_colp.py
@@ -19,8 +19,7 @@ class Scriptor(ScriptorInterface):
         self.__dict__.update(kwargs)
         
     def ingest(self) -> pd.DataFrame:
-        url = f"https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyc_colp_csv_{self.version}.zip"
-        r = requests.get(url, stream=True)
+        r = requests.get(self.path, stream=True)
         with open(f"nyc_colp_csv_{self.version}.zip", "wb") as fd:
             for chunk in r.iter_content(chunk_size=128):
                 fd.write(chunk)

--- a/library/script/dob_now_applications.py
+++ b/library/script/dob_now_applications.py
@@ -1,4 +1,3 @@
-from multiprocessing import connection
 import pandas as pd
 
 from .scriptor import ScriptorInterface

--- a/library/script/dob_now_permits.py
+++ b/library/script/dob_now_permits.py
@@ -1,4 +1,3 @@
-from multiprocessing import connection
 import pandas as pd
 
 from .scriptor import ScriptorInterface
@@ -7,8 +6,6 @@ from dotenv import load_dotenv
 import boto3
 import os
 import io
-
-from io import StringIO
 
 # Load environmental variables
 load_dotenv()

--- a/library/script/doe_lcgms.py
+++ b/library/script/doe_lcgms.py
@@ -1,5 +1,3 @@
-import json
-
 import pandas as pd
 import requests
 

--- a/library/script/doe_pepmeetingurls.py
+++ b/library/script/doe_pepmeetingurls.py
@@ -1,6 +1,3 @@
-import json
-import os
-import re
 import urllib
 from itertools import groupby
 from pathlib import Path

--- a/library/script/moeo_socialservicesitelocations.py
+++ b/library/script/moeo_socialservicesitelocations.py
@@ -1,7 +1,4 @@
-import json
-
 import pandas as pd
-import requests
 
 from . import df_to_tempfile
 

--- a/library/script/nycdoc_corrections.py
+++ b/library/script/nycdoc_corrections.py
@@ -1,11 +1,8 @@
-import json
-import os
 import re
 import ssl
 from urllib.request import Request, urlopen
 
 import pandas as pd
-import requests
 import usaddress
 from bs4 import BeautifulSoup
 

--- a/library/script/nysed_nonpublicenrollment.py
+++ b/library/script/nysed_nonpublicenrollment.py
@@ -1,7 +1,4 @@
-import json
-
 import pandas as pd
-import requests
 
 from . import df_to_tempfile
 from .scriptor import ScriptorInterface

--- a/library/script/usdot_airports.py
+++ b/library/script/usdot_airports.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import requests
 
 from . import df_to_tempfile
 from .scriptor import ScriptorInterface

--- a/library/templates/bpl_libraries.yml
+++ b/library/templates/bpl_libraries.yml
@@ -4,6 +4,7 @@ dataset:
   acl: public-read
   source:
     script: *name
+    path: "https://www.bklynlibrary.org/locations/json"
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"

--- a/library/templates/dcp_censusdata.yml
+++ b/library/templates/dcp_censusdata.yml
@@ -1,0 +1,32 @@
+dataset:
+  name: &name dcp_censusdata
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    script: *name
+    path: https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/census/census2020/nyc_decennialcensusdata_2010_2020_change-core-geographies.xlsx
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: null
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ###  Census
+      Decennial - high chance that 2030 will not follow same conventions
+      Currently has export with both data, 2010 or 2020 must be specified as version to determine which set of columns to use
+      This version does not contain data at the census block geography level
+    url: "https://www.nyc.gov/site/planning/planning-level/nyc-population/2020-census.page"
+    dependents: []

--- a/library/templates/dcp_censusdata.yml
+++ b/library/templates/dcp_censusdata.yml
@@ -27,6 +27,6 @@ dataset:
       ###  Census
       Decennial - high chance that 2030 will not follow same conventions
       Currently has export with both data, 2010 or 2020 must be specified as version to determine which set of columns to use
-      This version does not contain data at the census block geography level
+      This version contains data at the citywide, boro, community district, 2013 council district, 2020 NTA, and 2020 census track levels (no census blocks or CDTAs)
     url: "https://www.nyc.gov/site/planning/planning-level/nyc-population/2020-census.page"
     dependents: []

--- a/library/templates/dcp_censusdata_blocks.yml
+++ b/library/templates/dcp_censusdata_blocks.yml
@@ -1,0 +1,32 @@
+dataset:
+  name: &name dcp_censusdata_blocks
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    script: *name
+    path: https://s-media.nyc.gov/agencies/dcp/assets/files/excel/data-tools/census/census2020/nyc-decennialcensusdata_2010_2020_census-blocks.xlsx
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: null
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ###  Census
+      Decennial - high chance that 2030 will not follow same conventions
+      Currently has export with both data, 2010 or 2020 must be specified as version to determine which set of columns to use
+      This version contains data only at the city, boro, and census block level. See other census dataset for other geographies
+    url: "https://www.nyc.gov/site/planning/planning-level/nyc-population/2020-census.page"
+    dependents: []

--- a/tests/data/bpl_libraries_sql.yml
+++ b/tests/data/bpl_libraries_sql.yml
@@ -4,6 +4,7 @@ dataset:
   acl: public-read
   source:
     script: *name
+    path: "https://www.bklynlibrary.org/locations/json"
     options:
       - "AUTODETECT_TYPE=NO"
       - "EMPTY_STRING_AS_NULL=YES"


### PR DESCRIPTION
Two things.
- primary purpose - add yml templates and python scripts for dcp-provided census data for population and housing. There are two source files - one by blocks/borough/city, and one by ntas/community districts/council districts/borough/city. 
- some maintenance - a while back I edited a bunch of the scripts and made it so that path was specified in yml, not just hard-coded in a script (in the case of `script`-sourced dataset that are still pulling from just one endpoint). I missed bpl_libraries back then so added it now (and in the one test yml file that uses it)