### PR TITLE
add hpd historical data

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Archive datasets to S3 via CLI
 
 `library archive --name dcp_boroboundaries --version 22c --output-format csv`
 
-`library archive --name dcp_commercialoverlay --s3 --clean`
+`library archive --name dcp_commercialoverlay --s3 --latest`
 
 `library archive --name sca_e_pct --version 20230425 --output-format postgres --postgres-url $RECIPE_ENGINE`
 

--- a/library/script/hpd_historical_units_by_building.py
+++ b/library/script/hpd_historical_units_by_building.py
@@ -1,0 +1,18 @@
+import pandas as pd
+
+from . import df_to_tempfile
+from .scriptor import ScriptorInterface
+
+
+class Scriptor(ScriptorInterface):
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def ingest(self) -> pd.DataFrame:
+        df = pd.read_excel(self.path, sheet_name="LookBack Legislation (2)")
+        return df
+
+    def runner(self) -> str:
+        df = self.ingest()
+        local_path = df_to_tempfile(df)
+        return local_path

--- a/library/templates/hpd_historical_units_by_building.yml
+++ b/library/templates/hpd_historical_units_by_building.yml
@@ -1,0 +1,35 @@
+dataset:
+  name: &name hpd_historical_units_by_building
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    script: *name
+    path: library/tmp/HPD_FROM_DCP_HOUSING/06_20_2023_Lookback Legislation.xlsx
+    options:
+      - "AUTODETECT_TYPE=NO"
+      - "EMPTY_STRING_AS_NULL=YES"
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: null
+      type: NONE
+    options:
+      - "OVERWRITE=YES"
+      - "PRECISION=NO"
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ### Historical Units by Project
+      The Department of Housing Preservation and Development (HPD) reports on buildings, units, 
+      and projects that began after January 1, 2014 and are counted towards the Housing New York plan. 
+      The Historical Units by Project file presents the pre-2014 data by project, and includes project-level data, 
+      such as senior units, but does not include building-level data. 
+      The unit counts are provided for each project, rather than by building. 
+    url: null
+    dependents: []


### PR DESCRIPTION
related to https://github.com/NYCPlanning/data-engineering/issues/30

## goals
- be able to archive new source data: HPD Historical Units by Project (`hpd_historical_units_by_building`)

## changes
- add template file and python script
- change readme to have a more common example of `library archive` arguments

## notes
- emulates approach for similar source data `hpd_hny_units_by_building`
- screenshot of archived data in `edm-recipes` S3 bucket: <img width="833" alt="image" src="https://github.com/NYCPlanning/db-data-library/assets/7444289/f5704e85-4817-40bd-8905-23ef68cd7c9d">
- [successful use](https://github.com/NYCPlanning/data-engineering/actions/runs/5446509203/jobs/9907693169#step:4:145) of the archived data in a downstream process
