### PR TITLE
add 'as_is' output format option

### DIFF
--- a/library/cli.py
+++ b/library/cli.py
@@ -1,7 +1,4 @@
 import json
-import os
-import time
-from typing import Optional
 
 import typer
 from rich import box

--- a/library/s3.py
+++ b/library/s3.py
@@ -3,13 +3,13 @@ import os
 from pathlib import Path
 
 import boto3
+from botocore.client import Config 
 from botocore.exceptions import ClientError, ParamValidationError
 from rich.progress import (
     BarColumn,
     Progress,
     SpinnerColumn,
     TextColumn,
-    TimeElapsedColumn,
     TimeRemainingColumn,
 )
 
@@ -24,11 +24,13 @@ class S3:
         aws_s3_endpoint: str,
         aws_s3_bucket: str,
     ):
+        config = Config(read_timeout=120)
         self.client = boto3.client(
             "s3",
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             endpoint_url=aws_s3_endpoint,
+            config=config
         )
         self.bucket = aws_s3_bucket
 

--- a/library/sources.py
+++ b/library/sources.py
@@ -1,6 +1,6 @@
 import os
 
-from osgeo import gdal, ogr
+from osgeo import gdal
 
 from .utils import parse_engine
 

--- a/library/templates/dcp_pop_acs.yml
+++ b/library/templates/dcp_pop_acs.yml
@@ -1,0 +1,30 @@
+dataset:
+  name: &name dcp_pop_acs
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: library/tmp/acs_{{ version }}.xlsx
+      subpath: ""
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: null
+      type: NONE
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## ACS file from Population
+      This file is produced internally by the Population division. It contains data from the American Community Survey (ACS) 
+      with transformations made for it to be ingested by PFF pipeline (acs manual update)
+
+      It is received via email from the DCP Population division.
+      
+    url: null
+    dependents: []

--- a/library/templates/dcp_pop_decennial_dhc.yml
+++ b/library/templates/dcp_pop_decennial_dhc.yml
@@ -1,0 +1,30 @@
+dataset:
+  name: &name dcp_pop_decennial_dhc
+  version: "{{ version }}"
+  acl: public-read
+  source:
+    url:
+      path: library/tmp/dhc_{{ version }}.xlsx
+      subpath: ""
+    geometry:
+      SRS: null
+      type: NONE
+
+  destination:
+    name: *name
+    geometry:
+      SRS: null
+      type: NONE
+    fields: []
+    sql: null
+
+  info:
+    description: |
+      ## ACS Demographic and Housing Characteristics file from Population
+      This file is produced internally by the Population division. It contains data from multiple versions of the 
+      Census Demographic and Housing Characteristics (DHC) file with updated estimates for the current year. 
+      
+      It is received via email or file transfer from the DCP Population division
+      
+    url: null
+    dependents: []

--- a/library/validator.py
+++ b/library/validator.py
@@ -1,8 +1,6 @@
-from functools import cached_property
 from typing import List, Literal
 
-import yaml
-from pydantic import BaseModel, ValidationError, validator, Extra
+from pydantic import BaseModel, ValidationError, Extra
 
 VALID_ACL_VALUES = ("public-read", "private")
 VALID_GEOMETRY_TYPES = (


### PR DESCRIPTION
Added a raw file dump option (skip gdal), which needed:
- add "as_is" translator function
- modify ingest so that when "as_is" is specified as output format, gdal logic (and other logic around dstDS, srcDS, layerName, etc) is skipped and file is simply dumped to output location

Open to other names for this output format option!

Also added two templates, xlsx files which feed into pff and are therefor needed in their xlsx format. Could theoretically replace with script that has some logic of PFF but this seems like cleaner route for now, I don't have philosophical objection to having recipes that skip gdal. 

Other small changes
- Needed to extend the read_timeout for s3 client for these large xlsx files
- cleaned up some imports