### PR TITLE
Allow subpath for local zip archives, use gdal exceptions sooner in process

### DIFF
--- a/library/__init__.py
+++ b/library/__init__.py
@@ -17,6 +17,7 @@ pp = pprint.PrettyPrinter(indent=4)
 # gdal pg config, turn off warning
 gdal.SetConfigOption("PG_USE_COPY", "YES")
 gdal.SetConfigOption("CPL_LOG", "/dev/null")
+gdal.UseExceptions()
 
 # gdal configure aws s3 connection info
 aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]

--- a/library/ingest.py
+++ b/library/ingest.py
@@ -134,7 +134,6 @@ class Ingestor:
                     Path(dstDS).unlink()
 
 
-                gdal.UseExceptions()
                 gdal.VectorTranslate(
                     dstDS,
                     srcDS,

--- a/library/utils.py
+++ b/library/utils.py
@@ -32,15 +32,16 @@ def format_url(path: str, subpath: str) -> str:
     Adds "vsicurl" if [url] contains http
     - https://rawgithubcontent.come/somerepo/somefile.csv
     """
-    if os.path.isfile(path):
-        if ".zip" in path:
-            return "/vsizip/" + path
-        return path
 
     if len(subpath) > 0:
         subpath = subpath[1:] if subpath[0] == "/" else subpath
     path = path[:-1] if path[-1] == "/" else path
     url = path if len(subpath) == 0 else path + "/" + subpath
+
+    if os.path.isfile(path):
+        if ".zip" in url:
+            return "/vsizip/" + url
+        return url
 
     if ".zip" in url:
         if "http" in url:


### PR DESCRIPTION
First part should be self-explanatory.

For second part, I've been doing some testing locally with cpdb shape files. Currently, if a zipped shapefile is invalid in some way, this is discovered by loading the dataset without using exceptions, then [raising an error](https://github.com/NYCPlanning/db-data-library/blob/main/library/sources.py#L69) with `assert` if the dataset is `None`. It seems a bit more helpful to actually let gdal throw the error while loading the dataset instead (though in this case it does just say only slightly more verbosely that the zip file is not in a supported format). A little nervous about side-effects of this - do we have existing known "errors" that should be ignored? Should we always be throwing errors? I would think yes - a little odd that right now we only allow exceptions at the translate portion, not the loading of the dataset.

@damonmcc @alexrichey @AmandaDoyle

@athursland and @DeaBardhoshi just fyi